### PR TITLE
Board navigation edit

### DIFF
--- a/boardlist.txt
+++ b/boardlist.txt
@@ -1,0 +1,2 @@
+<!---This is an example header--->
+[<a href='/a' />a</a> / <a href='/b' />b</a> / <a href='/c' />c</a>]

--- a/configs/sample.php
+++ b/configs/sample.php
@@ -109,7 +109,7 @@ define(PLUG_PATH, 'plugins');                               //Plugins folder pat
 
 define(DUPE_CHECK, 0);                                //whether or not to check for duplicate images
 define(NAV_TXT, 'boardlist.txt');       //the file that contains your boardlist, displayed at both header and footer [a/b/c/][d/e/f/] etc.
-                                        //You have to set this yourself (for now)
+                                        //You have to set the contents of this file yourself (for now)
 define(S_DESCR, 'An imageboard powered by saguaro');    //meta description for this board
 define(EXTRA_SHIT, '');                                 //Any extra javascripts you want to include inside the <head>
 

--- a/configs/sample.php
+++ b/configs/sample.php
@@ -108,7 +108,8 @@ define(PLUG_PATH, 'plugins');                               //Plugins folder pat
 //Even more settings - there can never be enough
 
 define(DUPE_CHECK, 0);                                //whether or not to check for duplicate images
-define(S_BOARDLIST, '[a / b / c] | [d / e / f]');       //meta description for this board (LOOK AT THE README)
+define(NAV_TXT, 'boardlist.txt');       //the file that contains your boardlist, displayed at both header and footer [a/b/c/][d/e/f/] etc.
+                                        //You have to set this yourself (for now)
 define(S_DESCR, 'An imageboard powered by saguaro');    //meta description for this board
 define(EXTRA_SHIT, '');                                 //Any extra javascripts you want to include inside the <head>
 

--- a/imgboard.php
+++ b/imgboard.php
@@ -641,7 +641,7 @@ function insert(text)
 </head>
 <body>
  ' . $titlebar . '
-<span class="boardlist">' . S_BOARDLIST . ' </span>
+<span class="boardlist">' . get_file_contents(NAV_TXT) . ' </span>
 <span class="adminbar">
 [<a href="' . HOME . '" target="_top">' . S_HOME . '</a>]
 [<a href="' . PHP_SELF . '?mode=admin">' . S_ADMIN . '</a>]
@@ -743,7 +743,7 @@ function form( &$dat, $resno, $admin = "" )
 function foot( &$dat )
 {
 	$dat .= '
-<span class="boardlist">' . S_BOARDLIST . '</span>
+<span class="boardlist">' . get_file_contents(NAV_TXT) . '</span>
 <div class="footer">' . S_FOOT . '</div>
  
 </body></html>';


### PR DESCRIPTION
This makes it easier for users to reference a single txt file to display header/footer board listing. Eliminates the need for copying/pasting the list across multiple configs. Automating this is on the to-do list.
