### PR TITLE
#32 - Ban system bux fixing

### DIFF
--- a/banned.php
+++ b/banned.php
@@ -88,6 +88,7 @@ if ($ip == $host) {
             break;
         case '0':
             //They aren't banned...but the record reflects they have been before.
+            $status = 'are not banned';
             $type = 0;
             break;
         default:

--- a/imgboard.php
+++ b/imgboard.php
@@ -2384,6 +2384,7 @@ function oldvalid( $pass )
 	}
 }
 
+
 function ban( $ip, $pubreason, $staffreason, $banlength )
 {
     if (valid('moderator')) {


### PR DESCRIPTION
Resolves two bugs:
- Previous ban records showing up as active bans, preventing new bans from being placed
- Users with a previous ban on record visiting banned.php would see the "You are banned" header.
