### PR TITLE
Resolves imgboard hanging on post deletion

### DIFF
--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -250,13 +250,6 @@ class Log {
         if (isset($deferred))
             return $deferred;
         
-		if ($deferred) {
-				echo "<html><head><META HTTP-EQUIV=\"refresh\" content=\"2;URL=$redirect\"></head>";
-				echo "<body>$mes " . S_SCRCHANGE . "<br>Your post may not appear immediately.<!-- thread:$resto,no:$insertid --></body></html>";
-		} else {
-				echo "<html><head><META HTTP-EQUIV=\"refresh\" content=\"1;URL=$redirect\"></head>";
-				echo "<body>$mes " . S_SCRCHANGE . "<!-- thread:$resto,no:$insertid --></body></html>";
-		}
         return false;
     }
 

--- a/imgboard.php
+++ b/imgboard.php
@@ -194,7 +194,6 @@ switch ( $mode ) {
 		break;
     case 'usrdel':
         usrdel( $no, $pwd );
-        break;
     default:
         if ( $res ) {
             resredir( $res );


### PR DESCRIPTION
This fixes the long held usrdel issue where it would hang on imgboard.php after performing the deletion action. Fixes #99.

Note from 32f42e5804e2da0ceb9a9d5a1b35fb5940f5f201  :The absence of this break is intentional as it calls updatelog after performing the deletion action
