### PR TITLE
Html the reckoning

### DIFF
--- a/_core/general/foot.php
+++ b/_core/general/foot.php
@@ -16,7 +16,7 @@ class Footer {
         if (file_exists(BOARDLIST))
             $dat .= '<span class="boardlist">' . file_get_contents( BOARDLIST ) . '</span>';
 
-        $dat .= '<div class="footer">' . S_FOOT . '</div><a href="#bottom" /></a></body></html>';
+        $dat .= '<br><br><div class="footer">' . S_FOOT . '</div><a href="#bottom" /></a></div></body></html>'; //Last div ends the "afterPosts" class, opened in log.php
 
         return $dat;
     }

--- a/_core/general/head.php
+++ b/_core/general/head.php
@@ -60,26 +60,16 @@ class Head {
                 <script src='" . JS_PATH . "/styleswitch.js' type='text/javascript'></script>
                 <script src='" . JS_PATH . "/main.js' type='text/javascript'></script>";
 
-        if (USE_JS_SETTINGS)
-            $dat .= '<script src="' . JS_PATH . '/suite_settings.js" type="text/javascript"></script>';
-        if (USE_IMG_HOVER)
-            $dat .= '<script src="' . JS_PATH . '/image_hover.js" type="text/javascript"></script>';
-        if (USE_IMG_TOOLBAR)
-            $dat .= '<script src="' . JS_PATH . '/image_toolbar.js" type="text/javascript"></script>';
-        if (USE_IMG_EXP)
-            $dat .= '<script src="' . JS_PATH . '/image_expansion.js" type="text/javascript"></script>';
-        if (USE_UTIL_QUOTE)
-            $dat .= '<script src="' . JS_PATH . '/utility_quotes.js" type="text/javascript"></script>';
-        if (USE_INF_SCROLL)
-            $dat .= '<script src="' . JS_PATH . '/infinite_scroll.js" type="text/javascript"></script>';
-        if (USE_FORCE_WRAP)
-            $dat .= '<script src="' . JS_PATH . '/force_post_wrap.js" type="text/javascript"></script>';
-        if (USE_UPDATER)
-            $dat .= '<script src="' . JS_PATH . '/thread_updater.js" type="text/javascript"></script>';
-        if (USE_THREAD_STATS)
-            $dat .= '<script src="' . JS_PATH . '/thread_stats.js" type="text/javascript"></script>';
-        if (REPOD_EXTRA)
-            $dat .= '<script src="' . JS_PATH . '/extra/bgmod.js" type="text/javascript"></script>';
+        if (USE_JS_SETTINGS)       $dat .= '<script src="' . JS_PATH . '/suite_settings.js" type="text/javascript"></script>';
+        if (USE_IMG_HOVER)         $dat .= '<script src="' . JS_PATH . '/image_hover.js" type="text/javascript"></script>';
+        if (USE_IMG_TOOLBAR)     $dat .= '<script src="' . JS_PATH . '/image_toolbar.js" type="text/javascript"></script>';
+        if (USE_IMG_EXP)              $dat .= '<script src="' . JS_PATH . '/image_expansion.js" type="text/javascript"></script>';
+        if (USE_UTIL_QUOTE)        $dat .= '<script src="' . JS_PATH . '/utility_quotes.js" type="text/javascript"></script>';
+        if (USE_INF_SCROLL)        $dat .= '<script src="' . JS_PATH . '/infinite_scroll.js" type="text/javascript"></script>';
+        if (USE_FORCE_WRAP)    $dat .= '<script src="' . JS_PATH . '/force_post_wrap.js" type="text/javascript"></script>';
+        if (USE_UPDATER)            $dat .= '<script src="' . JS_PATH . '/thread_updater.js" type="text/javascript"></script>';
+        if (USE_THREAD_STATS)  $dat .= '<script src="' . JS_PATH . '/thread_stats.js" type="text/javascript"></script>';
+        if (REPOD_EXTRA)            $dat .= '<script src="' . JS_PATH . '/extra/bgmod.js" type="text/javascript"></script>';
         if (USE_EXTRAS) {
             foreach (glob(JS_PATH . "/extra/*.js") as $path) {
                 $dat .= "<script src='$path' type='text/javascript'></script>";
@@ -87,20 +77,18 @@ class Head {
             unset($path);
         }
 
-        $dat .= EXTRA_SHIT . '</head><body class="is_index">' . $titlebar . '
-                <span class="boardlist">' . ((file_exists(BOARDLIST)) ? file_get_contents(BOARDLIST) : ''). '</span>
-                <span class="adminbar">
-                [<a href="' . HOME . '" target="_top">' . S_HOME . '</a>]
-                [<a href="' . PHP_ASELF_ABS . '">' . S_ADMIN . '</a>]
-                </span>
-                <div class="logo">' . $titlepart . '</div>
+        $dat .= EXTRA_SHIT . '</head><body class="is_index"><div class="beforePostform" />' . $titlebar . '
+                <span class="boardList desktop">' . ((file_exists(BOARDLIST)) ? file_get_contents(BOARDLIST) : ''). '</div>
+                <div class="linkBar">[<a href="' . HOME . '" target="_top">' . S_HOME . '</a>][<a href="' . PHP_ASELF_ABS . '">' . S_ADMIN . '</a>]
+                </span><div class="logo">' . $titlepart . '</div>
                 <a href="#top" /></a>
                 <div class="headsub">' . S_HEADSUB . '</div><hr>';
 
         if (USE_ADS1) {
             $dat .= ADS1 . '<hr>';
         }
-
+        $dat .= "</div>";
+        
         return $dat;
     }
 }

--- a/_core/general/head.php
+++ b/_core/general/head.php
@@ -42,11 +42,20 @@ class Head {
                 <meta http-equiv='expires' content='Tue, 01 Jan 1980 1:00:00 GMT' />
                 <meta http-equiv='pragma' content='no-cache' />
                 <link rel='shortcut icon' href='" . CSS_PATH . "/imgs/favicon.ico'>
-                <title>$titlepart</title>
-                <link rel='stylesheet' type='text/css' href='" . CSS_PATH . CSS1 . "' title='Saguaba' />
-                <link rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS2 . "' title='Sagurichan'/>
-                <link rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS3 . "' title='Tomorrow' />
-                <link rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS4 . "' title='Burichan'/>
+                <title>$titlepart</title>";
+        
+        if (NSFW) {
+            $dat .= "<link rel='stylesheet' type='text/css' href='" . CSS_PATH . "/stylesheets/mobile.css' title='mobile' />
+                <link class='togglesheet' rel='stylesheet' type='text/css' href='" . CSS_PATH . CSS1 . "' title='Saguaba' />
+                <link class='togglesheet' rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS2 . "' title='Sagurichan' />";
+        } else {
+            $dat .= "<link rel='stylesheet' type='text/css' href='" . CSS_PATH . "/stylesheets/mobile.css' title='mobile' />
+            <link class='togglesheet' rel='stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS2 . "' title='Sagurichan' />
+            <link class='togglesheet' rel='alternate stylesheet' type='text/css' href='" . CSS_PATH . CSS1 . "' title='Saguaba' />";
+        }
+       
+       $dat  .= "<link class='togglesheet' rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS3 . "' title='Tomorrow' />
+                <link class='togglesheet' rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS4 . "' title='Burichan'/>
                 <script src='" . JS_PATH . "/jquery.min.js' type='text/javascript'></script>
                 <script src='" . JS_PATH . "/styleswitch.js' type='text/javascript'></script>
                 <script src='" . JS_PATH . "/main.js' type='text/javascript'></script>";
@@ -78,7 +87,7 @@ class Head {
             unset($path);
         }
 
-        $dat .= EXTRA_SHIT . '</head><body>' . $titlebar . '
+        $dat .= EXTRA_SHIT . '</head><body class="is_index">' . $titlebar . '
                 <span class="boardlist">' . ((file_exists(BOARDLIST)) ? file_get_contents(BOARDLIST) : ''). '</span>
                 <span class="adminbar">
                 [<a href="' . HOME . '" target="_top">' . S_HOME . '</a>]

--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -118,7 +118,7 @@ class Log {
             if (!$resno) {
                 $st = $page;
             }
-            $dat .= '<form name= "delform" action="' . PHP_SELF_ABS . '" method="post">';
+            $dat .= '<form name="delform" action="' . PHP_SELF_ABS . '" method="post">';
 
             for ($i = $st; $i < $st + PAGE_DEF; $i++) {
                 list($_unused, $no) = each($treeline);
@@ -131,7 +131,7 @@ class Log {
                 $thread = new Thread;
                 $thread->inIndex = ($resno) ? false : true;
                 $dat .= $thread->format($no);
-
+                
                 // Deletion pending
                 if (isset($log[$no]['old']))
                     $dat .= "<span class=\"oldpost\">" . S_OLD . "</span><br>\n";

--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -132,9 +132,9 @@ class Log {
                 $thread->inIndex = ($resno) ? false : true;
                 $dat .= $thread->format($no);
 
-                // Deletion pending
-                if (isset($log[$no]['old']))
-                    $dat .= "<span class=\"oldpost\">" . S_OLD . "</span><br>\n";
+                // Deletion pending (We'll disable this for now as it currently serves no purpose)
+                /*if (isset($log[$no]['old']))
+                    $dat .= "<span class=\"oldpost\">" . S_OLD . "</span><br>\n"; */
 
                 $resline = $log[$no]['children'];
                 ksort($resline);
@@ -176,11 +176,11 @@ class Log {
                     break;
                 } //only one tree line at time of res
             }
-
-            $dat .= '<table align="right"><tr><td class="delsettings" nowrap="nowrap" align="center">
+            //afterPosts div is closed in general/foot.php
+            $dat .= '<div class="afterPosts" /><table align="right"><tr><td class="delsettings" nowrap="nowrap" align="center">
     <input type="hidden" name="mode" value="usrdel" />' . S_REPDEL . '[<input type="checkbox" name="onlyimgdel" value="on" />' . S_DELPICONLY . ']
     ' . S_DELKEY . '<input type="password" name="pwd" size="8" maxlength="8" value="" />
-    <input type="submit" value="' . S_DELETE . '" /><input type="button" value="Report" onclick="var o=document.getElementsByTagName(\'INPUT\');for(var i=0;i<o.length;i++)if(o[i].type==\'checkbox\' && o[i].checked && o[i].value==\'delete\') return reppop(\'' . PHP_SELF_ABS . '?mode=report&no=\'+o[i].name+\'\');"></tr></td></form><script>document.delform.pwd.value=l(' . SITE_ROOT . '_pass");</script></td></tr></table>';
+    <input type="submit" value="' . S_DELETE . '" /><input type="button" value="Report" onclick="var o=document.getElementsByTagName(\'INPUT\');for(var i=0;i<o.length;i++)if(o[i].type==\'checkbox\' && o[i].checked && o[i].value==\'delete\') return reppop(\'' . PHP_SELF_ABS . '?mode=report&no=\'+o[i].name+\'\');"></tr></td></form><script>document.delform.pwd.value=l("saguaro_delpass");</script></td></tr></table>';
             /*<script language="JavaScript" type="script"><!--
             l();
             //--></script>';*/

--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -161,7 +161,7 @@ class Log {
 
 
                 /*possibility for ads after each post*/
-                $dat .= "</span><br clear=\"left\" /><hr />\n";
+                $dat .= "</span>\n";
 
                 if (USE_ADS3)
                     $dat .= ADS3 . '<hr>';

--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -161,7 +161,7 @@ class Log {
 
 
                 /*possibility for ads after each post*/
-                $dat .= "</span>\n";
+                $dat .= "</span><br clear=\"left\" /><hr />\n";
 
                 if (USE_ADS3)
                     $dat .= ADS3 . '<hr>';

--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -118,7 +118,7 @@ class Log {
             if (!$resno) {
                 $st = $page;
             }
-            $dat .= '<form name="delform" action="' . PHP_SELF_ABS . '" method="post">';
+            $dat .= '<form name= "delform" action="' . PHP_SELF_ABS . '" method="post">';
 
             for ($i = $st; $i < $st + PAGE_DEF; $i++) {
                 list($_unused, $no) = each($treeline);
@@ -131,7 +131,7 @@ class Log {
                 $thread = new Thread;
                 $thread->inIndex = ($resno) ? false : true;
                 $dat .= $thread->format($no);
-                
+
                 // Deletion pending
                 if (isset($log[$no]['old']))
                     $dat .= "<span class=\"oldpost\">" . S_OLD . "</span><br>\n";

--- a/_core/postform.php
+++ b/_core/postform.php
@@ -24,7 +24,7 @@ class PostForm {
 
         if ($resno) $temp .= "<div class='theader'>" . S_POSTING . "</div>\n";
 
-        $temp .= "<div align='center'><div class='postarea'>";
+        $temp .= "<div class='postForm' align='center'><div class='postarea'>";
         $temp .= "<form id='contribform' action='" . PHP_SELF_ABS . "' method='post' name='contrib' enctype='multipart/form-data'>";
 
         if ($admin) {
@@ -103,7 +103,8 @@ class PostForm {
             $news = file_get_contents(GLOBAL_NEWS);
 
             if ($news !== "")
-                $temp .= "<div class='globalnews'>" . file_get_contents( GLOBAL_NEWS ) . "</div><hr>";
+                $temp .= "<div class='globalNews desktop'>" . file_get_contents( GLOBAL_NEWS ) . "</div><hr>";
+                $temp .= "<div class='globalNewsM mobile'>" . file_get_contents( GLOBAL_NEWS ) . "<hr></div>";
         }
 
         if ($resno) //Navigation bar above thread.

--- a/_core/regist/tripcode.php
+++ b/_core/regist/tripcode.php
@@ -63,7 +63,7 @@ if ( preg_match( "/\#/", $names ) ) {
             
             $salt = strtr( preg_replace( "/[^\.-z]/", ".", substr( $trip . "H.", 1, 2 ) ), ":;<=>?@[\\]^_`", "ABCDEFGabcdef" );
             $trip = substr( crypt( $trip, $salt ), -10 );
-            $name .= " <span class='postertrip'>!" . $trip;
+            $name .= " <span class='name postertrip'>!" . $trip;
         }
     }
     
@@ -83,7 +83,7 @@ if ( preg_match( "/\#/", $names ) ) {
         $sha = base64_encode( pack( "H*", sha1( $sectrip . $salt ) ) );
         $sha = substr( $sha, 0, 11 );
         if ( $trip == "" )
-            $name .= " <span class='postertrip' style='color:#117743'>";
+            $name .= " <span class='name postertrip'>";
         $name .= "!!" . $sha;
     }
 }

--- a/_core/thread/image.php
+++ b/_core/thread/image.php
@@ -69,7 +69,7 @@ class Image {
             } else {
                 $dimensions = ( $ext == ".pdf" ) ? "PDF" : "{$w}x{$h}";
                 if (!$this->inIndex) {
-                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ", <span title='" . $longname . "'>" . $shortname . "</span>)</span>" . $imgsrc . "</div></div>";
+                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ", <span title='" . $longname . "'>" . $shortname . "</span>)</span>" . $imgsrc . "</div>";
                 } else {
                     return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ")</div></span><div class='fileThumb' />" . $imgsrc . "</div>";
                 }

--- a/_core/thread/image.php
+++ b/_core/thread/image.php
@@ -69,9 +69,9 @@ class Image {
             } else {
                 $dimensions = ( $ext == ".pdf" ) ? "PDF" : "{$w}x{$h}";
                 if (!$this->inIndex) {
-                    return "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class='filesize'>" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a>-(" . $size . "B, " . $dimensions . ", <span title='" . $longname . "'>" . $shortname . "</span>)</span>" . $imgsrc;
+                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ", <span title='" . $longname . "'>" . $shortname . "</span>)</span>" . $imgsrc . "</div></div>";
                 } else {
-                    return "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class='filesize'>" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a>-(" . $size . "B, " . $dimensions . ")</span>" . $imgsrc;
+                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ")</div></span><div class='fileThumb' />" . $imgsrc . "</div></div>";
                 }
             }
 

--- a/_core/thread/image.php
+++ b/_core/thread/image.php
@@ -68,10 +68,10 @@ class Image {
                 $return .= "<img src='" . $cssimg . "/imgs/filedeleted.gif' alt='File deleted.'>";
             } else {
                 $dimensions = ( $ext == ".pdf" ) ? "PDF" : "{$w}x{$h}";
-                if (!$this->inIndex) {
-                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ", <span title='" . $longname . "'>" . $shortname . "</span>)</span>" . $imgsrc . "</div>";
+                if (!$this->inIndex) { //, <span title='" . $longname . "'>" . $shortname . "</span>)
+                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$shortname</a> (" . $size . "B, " . $dimensions . ")</span>" . $imgsrc . "</div>";
                 } else {
-                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ")</div></span><div class='fileThumb' />" . $imgsrc . "</div>";
+                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$shortname</a> (" . $size . "B, " . $dimensions . ")</div></span><div class='fileThumb' />" . $imgsrc . "</div>";
                 }
             }
 

--- a/_core/thread/image.php
+++ b/_core/thread/image.php
@@ -71,7 +71,7 @@ class Image {
                 if (!$this->inIndex) {
                     return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ", <span title='" . $longname . "'>" . $shortname . "</span>)</span>" . $imgsrc . "</div></div>";
                 } else {
-                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ")</div></span><div class='fileThumb' />" . $imgsrc . "</div></div>";
+                    return "<div class='file'><span class='filesize' />" . S_PICNAME . "<a href='$linksrc' target='_blank'>$time$ext</a> (" . $size . "B, " . $dimensions . ")</div></span><div class='fileThumb' />" . $imgsrc . "</div>";
                 }
             }
 

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -76,9 +76,6 @@ class Post {
         $temp .= "<blockquote class='postMessage' id='m$no'>$com</blockquote>";
 
         $temp .= "</td></tr></table></div>\n";
-        
-        if ($this->inIndex)
-            $temp .= "<br clear=\"left\" /><hr />";
 
         return $temp;
     }

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -13,6 +13,35 @@ class Post {
     public $data = [];
     public $inIndex = false; //Until I feel like extending.
 
+    function formatOP() {
+        extract($this->data);
+
+        $image = new Image;
+        $image->inIndex = $this->inIndex;
+        $temp = $image->format($this->data);
+
+        $temp .= "<input type=checkbox name='$no' value=delete>";
+        $temp .= "<span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now</span> <span id='nothread$no'>";
+
+        $stickyicon = ($sticky) ? ' <img src="' . CSS_PATH . '/imgs/sticky.gif" alt="sticky"> ' : "";
+
+        if ($locked) $stickyicon .= ' <img src="' . CSS_PATH . '/imgs/locked.gif" alt="closed"> ';
+
+        if (!$this->inIndex) {
+            $temp .= "<a href='#$no' class='quotejs'>No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a> $stickyicon &nbsp; ";
+        } else {
+            $temp .= "<a href='" . RES_DIR . $no . PHP_EXT . "#" . $no . "' class='quotejs'>No.</a><a href='" . RES_DIR . $no . PHP_EXT . "#q" . $no . "' class='quotejs'>$no</a> $stickyicon &nbsp; [<a href='" . RES_DIR . $no . PHP_EXT . "'>" . S_REPLY . "</a>]";
+        }
+
+        $com = $this->abbr($com, MAX_LINES_SHOWN);
+        $com = $this->auto_link($com, $no);
+
+        $temp .= "<br>";
+        $temp .= "</span>\n<blockquote class='postMessage' id='m$no'>$com</blockquote>";
+
+        return $temp;
+    }   
+    
     function format() {
         extract($this->data);
 
@@ -24,10 +53,9 @@ class Post {
             $spoiler = 0;
         }
 
-        $temp = "<a name='$no'></a>\n";
-        $temp .= "<table><tr><td nowrap class='doubledash'>&gt;&gt;</td><td id='$no' class='reply'>\n";
-        $temp .= "<input type=checkbox name='$no' value=delete><span class='replytitle'>$sub</span> \n";
-        $temp .= "<span class='commentpostername'>$name</span> $now <span id='norep$no'>";
+        $temp .= "<table><tr><td nowrap class='sideArrows' id='sa$no'>&gt;&gt;</td><td id='$no' class='reply'>\n";
+        $temp .= "<input type=checkbox name='$no' value=delete>";
+        $temp .= "<span class='subject'>$sub</span> \n<span class='name'>$name</span> <span class='dateTime' />$now</span> <span id='norep$no'>";
 
         $com = $this->abbr($com, MAX_LINES_SHOWN);
         $com = $this->auto_link($com, $resno);
@@ -44,38 +72,9 @@ class Post {
         $image->inIndex = $this->inIndex;
         $temp .= $image->format($this->data);
 
-        $temp .= "<blockquote>$com</blockquote>";
+        $temp .= "<blockquote class='postMessage' id='m$no'>$com</blockquote>";
 
         $temp .= "</td></tr></table>\n";
-
-        return $temp;
-    }
-
-    function formatOP() {
-        extract($this->data);
-
-        $image = new Image;
-        $image->inIndex = $this->inIndex;
-        $temp = $image->format($this->data);
-
-        $temp .= "<a name='$resno'></a>\n<input type=checkbox name='$no' value=delete><span class='filetitle'>$sub</span> \n";
-        $temp .= "<span class='postername'>$name</span> $now <span id='nothread$no'>";
-
-        $stickyicon = ($sticky) ? ' <img src="' . CSS_PATH . '/imgs/sticky.gif" alt="sticky"> ' : "";
-
-        if ($locked) $stickyicon .= ' <img src="' . CSS_PATH . '/imgs/locked.gif" alt="closed"> ';
-
-        if (!$this->inIndex) {
-            $temp .= "<a href='#$no' class='quotejs'>No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a> $stickyicon &nbsp; ";
-        } else {
-            $temp .= "<a href='" . RES_DIR . $no . PHP_EXT . "#" . $no . "' class='quotejs'>No.</a><a href='" . RES_DIR . $no . PHP_EXT . "#q" . $no . "' class='quotejs'>$no</a> $stickyicon &nbsp; [<a href='" . RES_DIR . $no . PHP_EXT . "'>" . S_REPLY . "</a>]";
-        }
-
-        $com = $this->abbr($com, MAX_LINES_SHOWN);
-        $com = $this->auto_link($com, $no);
-
-        $temp .= "<br>";
-        $temp .= "</span>\n<blockquote>$com</blockquote>";
 
         return $temp;
     }

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -15,7 +15,7 @@ class Post {
 
     function formatOP() {
         extract($this->data);
-        $temp = "<div class='thread' id='t$no'/><div class='postContainer opContainer' id='pc$no'/>";
+        $temp = "<div class='thread' id='t$no'/><div class='post op' id='p$no'/><div class='postContainer opContainer' id='pc$no'/>";
 
         $image = new Image;
         $image->inIndex = $this->inIndex;
@@ -39,7 +39,7 @@ class Post {
 
         $temp .= "<br>";
         $temp .= "</span>\n<blockquote class='postMessage' id='m$no'>$com</blockquote>";
-        $temp .= "</div>";
+        $temp .= "</div></div>";
         return $temp;
     }   
     

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -20,25 +20,27 @@ class Post {
         $image = new Image;
         $image->inIndex = $this->inIndex;
         $temp .= $image->format($this->data);
-
-        $temp .= "<input type=checkbox name='$no' value=delete>";
-        $temp .= "<span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now</span> <span id='nothread$no'>";
+        
+        $temp .= "<div class='postInfoM mobile' id='pim$no'/><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now</span></div>";
+        $temp .= "<div class='postInfo desktop'><input type=checkbox name='$no' value=delete><span class='subject'>$sub</span> \n<span class='name'>$name</span> <span class='dateTime' />$now</span>";
 
         $stickyicon = ($sticky) ? ' <img src="' . CSS_PATH . '/imgs/sticky.gif" alt="sticky"> ' : "";
 
         if ($locked) $stickyicon .= ' <img src="' . CSS_PATH . '/imgs/locked.gif" alt="closed"> ';
 
         if (!$this->inIndex) {
-            $temp .= "<a href='#$no' class='quotejs'>No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a> $stickyicon &nbsp; ";
+            $temp .= "<a href='#$no' class='quotejs' >No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a> $stickyicon ";
         } else {
-            $temp .= "<a href='" . RES_DIR . $no . PHP_EXT . "#" . $no . "' class='quotejs'>No.</a><a href='" . RES_DIR . $no . PHP_EXT . "#q" . $no . "' class='quotejs'>$no</a> $stickyicon &nbsp; [<a href='" . RES_DIR . $no . PHP_EXT . "'>" . S_REPLY . "</a>]";
+            $temp .= "  <a href='" . RES_DIR . $no . PHP_EXT . "#" . $no . "' class='quotejs'>No.</a><a href='" . RES_DIR . $no . PHP_EXT . "#q" . $no . "' class='quotejs'>$no</a> $stickyicon [<a href='" . RES_DIR . $no . PHP_EXT . "'>" . S_REPLY . "</a>]</div>";
+            $temp .= "<div class='postLink mobile' > $stickyicon &nbsp; <a href='" . RES_DIR . $no . PHP_EXT . "'>" . S_REPLY . "</a></div>";
+        
         }
 
         $com = $this->abbr($com, MAX_LINES_SHOWN);
         $com = $this->auto_link($com, $no);
 
         $temp .= "<br>";
-        $temp .= "</span>\n<blockquote class='postMessage' id='m$no'>$com</blockquote>";
+        $temp .= "<blockquote class='postMessage' id='m$no' >$com</blockquote>";
         $temp .= "</div></div>";
         return $temp;
     }   
@@ -54,28 +56,29 @@ class Post {
             $spoiler = 0;
         }
         $temp .= "<div class='postContainer replyContainer' id='pc$no'/>";
-        $temp .= "<table><tr><td nowrap class='sideArrows' id='sa$no'>&gt;&gt;</td><td id='$no' class='reply'>\n";
-        $temp .= "<input type=checkbox name='$no' value=delete>";
-        $temp .= "<span class='subject'>$sub</span> \n<span class='name'>$name</span> <span class='dateTime' />$now</span> <span id='norep$no'>";
+        $temp .= "<div class='sideArrows' id='sa$no'>&gt;&gt;</div><div id='$no' class='post reply'>\n";
+        
 
-        $com = $this->abbr($com, MAX_LINES_SHOWN);
-        $com = $this->auto_link($com, $resno);
+        
+        $temp .= "<div class='postInfoM mobile' id='pim$no'/><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now</span></div>";
+        $temp .= "<div class='postInfo desktop'><input type=checkbox name='$no' value=delete><span class='subject'>$sub</span> \n<span class='name'>$name</span> <span class='dateTime' />$now</span> ";
 
         if (!$this->inIndex) {
-            $temp .= "<a href='#$no' class='quotejs'>No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a></span>";
+            $temp .= "<a href='#$no' class='quotejs'>No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a></span></div>";
         } else {
-            $temp .= "<a href='" . RES_DIR . $resto . PHP_EXT . "#$no' class='quotejs'>No.</a><a href='" . RES_DIR . $resto . PHP_EXT . "#q$no' class='quotejs'>$no</a></span>";
+            $temp .= "<a href='" . RES_DIR . $resto . PHP_EXT . "#$no' class='quotejs'>No.</a><a href='" . RES_DIR . $resto . PHP_EXT . "#q$no' class='quotejs'>$no</a></div>";
         }
-
-        $temp .= "<br>";
 
         $image = new Image;
         $image->inIndex = $this->inIndex;
         $temp .= $image->format($this->data);
 
+        $com = $this->abbr($com, MAX_LINES_SHOWN);
+        $com = $this->auto_link($com, $resno);
+
         $temp .= "<blockquote class='postMessage' id='m$no'>$com</blockquote>";
 
-        $temp .= "</td></tr></table></div>\n";
+        $temp .= "</div></div>\n";
 
         return $temp;
     }

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -15,10 +15,11 @@ class Post {
 
     function formatOP() {
         extract($this->data);
+        $temp = "<div class='postContainer opContainer' id='pc$no'/>";
 
         $image = new Image;
         $image->inIndex = $this->inIndex;
-        $temp = $image->format($this->data);
+        $temp .= $image->format($this->data);
 
         $temp .= "<input type=checkbox name='$no' value=delete>";
         $temp .= "<span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now</span> <span id='nothread$no'>";
@@ -38,7 +39,7 @@ class Post {
 
         $temp .= "<br>";
         $temp .= "</span>\n<blockquote class='postMessage' id='m$no'>$com</blockquote>";
-
+        $temp .= "</div>";
         return $temp;
     }   
     
@@ -52,7 +53,7 @@ class Post {
         } else {
             $spoiler = 0;
         }
-
+        $temp .= "<div class='postContainer replyContainer' id='pc$no'/>";
         $temp .= "<table><tr><td nowrap class='sideArrows' id='sa$no'>&gt;&gt;</td><td id='$no' class='reply'>\n";
         $temp .= "<input type=checkbox name='$no' value=delete>";
         $temp .= "<span class='subject'>$sub</span> \n<span class='name'>$name</span> <span class='dateTime' />$now</span> <span id='norep$no'>";
@@ -74,7 +75,7 @@ class Post {
 
         $temp .= "<blockquote class='postMessage' id='m$no'>$com</blockquote>";
 
-        $temp .= "</td></tr></table>\n";
+        $temp .= "</td></tr></table></div>\n";
 
         return $temp;
     }

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -15,7 +15,7 @@ class Post {
 
     function formatOP() {
         extract($this->data);
-        $temp = "<div class='postContainer opContainer' id='pc$no'/>";
+        $temp = "<div class='thread' id='t$no'/><div class='postContainer opContainer' id='pc$no'/>";
 
         $image = new Image;
         $image->inIndex = $this->inIndex;
@@ -76,6 +76,9 @@ class Post {
         $temp .= "<blockquote class='postMessage' id='m$no'>$com</blockquote>";
 
         $temp .= "</td></tr></table></div>\n";
+        
+        if ($this->inIndex)
+            $temp .= "<br clear=\"left\" /><hr />";
 
         return $temp;
     }

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -21,15 +21,15 @@ class Post {
         $image->inIndex = $this->inIndex;
         $temp .= $image->format($this->data);
         
-        $temp .= "<div class='postInfoM mobile' id='pim$no'/><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now</span></div>";
-        $temp .= "<div class='postInfo desktop'><input type=checkbox name='$no' value=delete><span class='subject'>$sub</span> \n<span class='name'>$name</span> <span class='dateTime' />$now</span>";
+        $temp .= "<div class='postInfoM mobile' id='pim$no'/><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now  <a href='#$no' class='quotejs' >No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a></span></div>";
+        $temp .= "<div class='postInfo desktop'><input type=checkbox name='$no' value=delete><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now</span>";
 
         $stickyicon = ($sticky) ? ' <img src="' . CSS_PATH . '/imgs/sticky.gif" alt="sticky"> ' : "";
 
         if ($locked) $stickyicon .= ' <img src="' . CSS_PATH . '/imgs/locked.gif" alt="closed"> ';
 
         if (!$this->inIndex) {
-            $temp .= "<a href='#$no' class='quotejs' >No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a> $stickyicon ";
+            $temp .= "<a href='#$no' class='quotejs' >No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a> $stickyicon </div>";
         } else {
             $temp .= "  <a href='" . RES_DIR . $no . PHP_EXT . "#" . $no . "' class='quotejs'>No.</a><a href='" . RES_DIR . $no . PHP_EXT . "#q" . $no . "' class='quotejs'>$no</a> $stickyicon [<a href='" . RES_DIR . $no . PHP_EXT . "'>" . S_REPLY . "</a>]</div>";
             $temp .= "<div class='postLink mobile' > $stickyicon &nbsp; <a href='" . RES_DIR . $no . PHP_EXT . "'>" . S_REPLY . "</a></div>";
@@ -56,12 +56,10 @@ class Post {
             $spoiler = 0;
         }
         $temp .= "<div class='postContainer replyContainer' id='pc$no'/>";
-        $temp .= "<div class='sideArrows' id='sa$no'>&gt;&gt;</div><div id='$no' class='post reply'>\n";
+        $temp .= "<div class='sideArrows' id='sa$no'>&gt;&gt;</div><div id='$no' class='post reply'>";
         
-
-        
-        $temp .= "<div class='postInfoM mobile' id='pim$no'/><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now</span></div>";
-        $temp .= "<div class='postInfo desktop'><input type=checkbox name='$no' value=delete><span class='subject'>$sub</span> \n<span class='name'>$name</span> <span class='dateTime' />$now</span> ";
+        $temp .= "<div class='postInfoM mobile' id='pim$no'/><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now  <a href='#$no' class='quotejs' >No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a><span></div>";
+        $temp .= "<div class='postInfo desktop'><input type=checkbox name='$no' value=delete><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' />$now</span> ";
 
         if (!$this->inIndex) {
             $temp .= "<a href='#$no' class='quotejs'>No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a></span></div>";
@@ -78,7 +76,7 @@ class Post {
 
         $temp .= "<blockquote class='postMessage' id='m$no'>$com</blockquote>";
 
-        $temp .= "</div></div>\n";
+        $temp .= "</div></div>";
 
         return $temp;
     }

--- a/_core/thread/thread.php
+++ b/_core/thread/thread.php
@@ -81,7 +81,8 @@ class Thread {
             $image .= ($omit_images == 1) ? "" : "s";
             $and_images = ($omit_images > 0) ? "and $omit_images $image" : "";
 
-            $temp .= "<span class='omittedposts'>$omit_replies $post $and_images omitted. Click <a href='" . RES_DIR . $op . PHP_EXT . "#" . $op . "'> " . S_REPLY . "</a> to view.</span>";
+            $temp .= "<span class='summary'>$omit_replies $post $and_images omitted. Click <a href='" . RES_DIR . $op . PHP_EXT . "#" . $op . "'> " . S_REPLY . "</a> to view.</span>";
+
         }
 
 

--- a/_core/thread/thread.php
+++ b/_core/thread/thread.php
@@ -88,7 +88,7 @@ class Thread {
         foreach ($temp_a as $entry) {
             $temp .= $this->generateReply($entry);
         }
-
+        $temp .= "</div>"; //Close thread div started in formatOP(), post.php
         return $temp;
     }
 

--- a/config.php
+++ b/config.php
@@ -104,7 +104,7 @@ define(MAX_DURATION, 60);   //The maximum duration allowed in seconds.
 //RePod's JS suite
 define(USE_JS_SETTINGS, 1); //Include the JS suite's settings - enables user side settings
 define(USE_IMG_HOVER, 1);   //Use image expansion on hover
-define(USE_IMG_TOOLBAR, 1); //Use the image search toolbars
+define(USE_IMG_TOOLBAR, 0); //Use the image search toolbars
 define(USE_IMG_EXP, 1);     //Use image expansion
 define(USE_UTIL_QUOTE, 1);  //Use utility quotes
 define(USE_INF_SCROLL, 0);  //Use infinite scroll

--- a/config.php
+++ b/config.php
@@ -39,6 +39,7 @@ define(GLOBAL_NEWS, 'CHANGEME'); //Absolute html path to your global board news 
 define(SALTFILE, 'salt');        //Name of the salt file, do not add a file extension for security
 
 //Basic settings
+define(NSFW_BOARD, false);    //Whether or not this is a NSFW(Red/Saguaba or blue/Sagurichan) board. Also affects mobile theme.
 define(SHOWTITLETXT, true);   //Show TITLE at top.
 define(SHOWTITLEIMG, 0);      //Show image at top (0: no, 1: single, 2: rotating)
 define(TITLEIMG, '');         //Title image (point to php file if rotating)

--- a/css/stylesheets/mobile.css
+++ b/css/stylesheets/mobile.css
@@ -1,0 +1,667 @@
+@media only screen and (max-width: 480px) {
+    html {
+        -moz-text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+    }
+    .postMenuBtn {
+        -webkit-transform: rotate(90deg);
+        -moz-transform: rotate(90deg);
+        -ms-transform: rotate(90deg);
+        transform: rotate(90deg);
+        margin: 4px -5px 0px 4px!important;
+        float: left;
+        font-weight: bold;
+        opacity: 1!important;
+        height: 0.5em!important;
+        font-size: 16px;
+    }
+    .dd-menu {
+        font-size: 16px;
+        line-height: 2em;
+    }
+    .party-hat {
+        left: -15px;
+        margin-top: -30px;
+        position: absolute;
+        width: 100px;
+        pointer-events: none;
+    }
+    body {
+        background: inherit;
+        color: inherit;
+        font-family: arial, helvetica, sans-serif;
+        font-size: 10pt;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 5px;
+        padding-left: 0px;
+        padding-right: 0px;
+        width: 100%;
+    }
+    .ad-plea,
+    embed {
+        display: none!important;
+    }
+    a,
+    .useremail:not(:hover) .name:not(.capcode),
+    .useremail:not(:hover) .postertrip:not(.capcode) {
+        color: #34345C!important;
+    }
+    a.replylink,
+    div#absbot a {
+        text-decoration: underline!important;
+    }
+    a.replylink:not(:hover),
+    div#absbot a:not(:hover) {
+        color: #34345C!important;
+    }
+    a:hover,
+    .useremail .name:hover,
+    .useremail .postertrip:hover,
+    a.quoteLink:hover,
+    a.quotelink:hover,
+    a.deadlink:hover,
+    .useremail *:hover,
+    .useremail:hover * {
+        color: #DD0000!important;
+    }
+    .posteruid .hand:hover {
+        color: #DD0000!important;
+    }
+    img {
+        border: none;
+    }
+    .postNum {
+        display: none;
+    }
+    img.topad,
+    .topad>div,
+    .topad a img {
+        width: 320px;
+        height: 40px;
+        max-width: 100%;
+        overflow: hidden;
+        margin: auto;
+    }
+    img.middlead,
+    .middlead>div,
+    .middlead a img {
+        width: 234px;
+        height: 30px;
+        max-width: 100%;
+        overflow: hidden;
+        margin: auto;
+    }
+    img.bottomad,
+    .bottomad>div,
+    .bottomad a img {
+        width: 320px;
+        height: 40px;
+        max-width: 100%;
+        overflow: hidden;
+        margin: auto;
+    }
+    ul.rules {
+        display: none;
+    }
+    .button a {
+        text-decoration: none!important;
+    }
+    div.boardBanner {
+        margin-top: 40px!important;
+    }
+    .backlink.mobile {
+        background-color: #C9CDE8;
+        border-top: 1px solid #B7C5D9;
+    }
+    .mobile {
+        display: block!important;
+        clear: left!important;
+    }
+    .noPictures .mFileInfo {
+        display: none!important;
+    }
+    .postLink.mobile {
+        clear: both!important;
+    }
+    .mobileinline {
+        display: inline!important;
+    }
+    .mobileib {
+        display: inline-block!important;
+    }
+    span.replyTextM {
+        display: inline!important;
+    }
+    .desktop {
+        display: none!important;
+    }
+    .hideMobile {
+        display: none!important;
+    }
+    div.board>hr {
+        border: none;
+        border-top: 1px solid #B7C5D9;
+        height: 0;
+        margin-top: 30px!important;
+        margin-bottom: 30px!important;
+    }
+    div.board>hr:last-of-type {
+        margin-bottom: 10px!important;
+    }
+    hr.abovePostForm {
+        width: 90%;
+    }
+    span.x-small {
+        font-size: x-small;
+    }
+    div.postLink {
+        background-color: #c9cde8;
+        border-top: 1px solid #B7C5D9;
+        padding: 5px;
+        overflow: hidden;
+        margin: -5px;
+    }
+    div.postLink span {
+        float: left;
+    }
+    div.postLink a {
+        float: right;
+        color: #34345C!important;
+    }
+    .mobilePostFormToggle {
+        text-align: center;
+        font-weight: bold;
+        margin: 0 auto;
+        padding-top: 15px;
+    }
+    a.mobilePostFormToggle {
+        text-align: center;
+        display: inline-block!important;
+    }
+    div.mobilePostFormToggle div {
+        width: 300px;
+        background-color: #98E;
+        padding-top: 5px;
+        padding-bottom: 5px;
+        border: 1px solid #000;
+        margin: 0 auto;
+    }
+    div.post div.file .fileThumb img {
+        max-width: 100px;
+        max-height: 100px;
+    }
+    span.fileThumb {
+        margin-left: 0px!important;
+        margin-right: 5px!important;
+    }
+    div.post div.file .fileThumb {
+        margin-left: 5px!important;
+        margin-right: 10px!important;
+        text-decoration: none;
+    }
+    div.post div.file div.fileText {
+        display: none;
+    }
+    div.sideArrows {
+        display: none;
+    }
+    div.reply {
+        padding: 2px;
+        background-color: #D6DAF0;
+        margin: 0px;
+        border: 1px solid #B7C5D9;
+        display: inline-block;
+    }
+    div.replyContainer {
+        background-color: #D6DAF0;
+        margin: 5px 5px 0 5px;
+        padding-left: 0;
+    }
+    .is_index div.thread {
+        padding: 0 7px;
+    }
+    .is_index div.replyContainer {
+        margin: 7px 0 0 0;
+    }
+    .is_index div.opContainer {
+        margin: 0 -7px;
+    }
+    div.opContainer {
+        padding: 5px;
+        display: block;
+        overflow: hidden;
+        background-color: #D6DAF0;
+        border: 1px solid #B7C5D9!important;
+    }
+    span.summary:not(.preview-summary) {
+        padding: 5px;
+        text-align: center;
+        display: block;
+        background-color: #c9cde8;
+        border-bottom: 1px solid #B7C5D9!important;
+        margin-top: 0px;
+        margin-bottom: 5px;
+        font-weight: bold;
+    }
+    div.postLink span.info {
+        color: #34345C;
+        margin-top: 8px;
+    }
+    blockquote {
+        margin: 10px!important;
+    }
+    blockquote.postMessage {
+        font-size: 11pt;
+        word-wrap: break-word;
+        padding: 5px;
+    }
+    .omittedposts,
+    .abbr {
+        color: #707070!important;
+        font-size: 10pt!important;
+    }
+    div.thread {
+        border-top: none;
+    }
+    div.opContainer div.postInfo {
+        display: none!important;
+    }
+    div.post div.postInfoM {
+        overflow: hidden;
+        border-bottom: 1px solid #B7C5D9;
+        background-color: #c9cde8;
+        padding: 5px;
+        margin: -5px -6px 5px -5px;
+    }
+    div.replyContainer div.postInfoM {
+        margin: 0px;
+    }
+    div.post div.postInfoM span.postNum,
+    div.postInfo span.postNum {
+        float: left;
+    }
+    div.post div.postInfoM span.postNum a,
+    div.postInfo span.postNum a {
+        text-decoration: none;
+        color: #000000!important;
+    }
+    div.post div.postInfoM span.postNum a:hover {
+        color: red;
+    }
+    div.post div.postInfoM span.nameBlock,
+    div.postInfo span.nameBlock {
+        display: inline;
+        float: left;
+        clear: left;
+    }
+    div.post div.postInfoM span.nameBlock span.name,
+    div.postInfo span.nameBlock span.name {
+        color: #117743;
+        font-weight: bold;
+    }
+    div.post div.postInfoM span.nameBlock span.tripcode,
+    div.postInfo span.nameBlock span.tripcode {
+        color: #117743;
+    }
+    div.post div.postInfoM span.dateTime {
+        float: right;
+        text-align: right;
+        color: black!important;
+    }
+    div.post div.postInfoM span.time {}div.post div.postInfoM span.subject {
+        color: #0F0C5D;
+        font-weight: bold;
+    }
+    span.fileText {
+        font-size: smaller;
+    }
+    div.replyContainer div.reply {
+        width: 100%;
+        padding: 0px!important;
+    }
+    div.replyContainer div.post div.postInfo {
+        overflow: hidden;
+        border-bottom: 1px solid #B7C5D9;
+        background-color: #c9cde8;
+        padding: 3px;
+        margin: 0px;
+    }
+    div.replyContainer div.post div.postInfo input[type=checkbox] {
+        display: none;
+    }
+    div.replyContainer div.post div.postInfo span.postNum {
+        font-style: italic;
+    }
+    div.replyContainer div.post div.postInfo span.userInfo {
+        float: left;
+        padding-left: 5px;
+    }
+    div.replyContainer div.post div.postInfo span.nameBlock {}div.replyContainer div.post div.postInfo span.postNum a:first-child:after {
+        content: " ";
+    }
+    div.replyContainer div.post div.postInfo span.dateTime {
+        float: right;
+        text-align: right;
+        padding-right: 10px;
+        font-style: italic;
+    }
+    div.replyContainer div.post div.postInfo span.dateTime span.date {
+        display: block;
+    }
+    div.thread>div:nth-of-type(2)>div.reply {
+        margin-top: 0px!important;
+    }
+    div.replyContainer div.post div.fileInfo {
+        margin-left: 0px;
+    }
+    div.replyContainer div.post div.file {
+        padding: 5px;
+    }
+    div.mPagelist {
+        margin-top: 10px;
+        text-align: center;
+        border-bottom: 1px solid #B7C5D9;
+        padding-bottom: 10px;
+        color: #89A;
+    }
+    div.mPagelist strong {
+        color: #34345C;
+    }
+    div.mPagelist>div.prev,
+    div.mPagelist div.next {
+        margin: 20px 2px 15px;
+        display: inline-block;
+    }
+    .button {
+        border-radius: 3px;
+        padding: 6px 10px 5px 10px;
+        font-weight: bold;
+        background-color: #D6DAF0;
+        border: 1px solid #B7C5D9;
+        user-select: none;
+        background-image: url(/image/buttonfade-blue.png);
+        background-repeat: repeat-x;
+        text-decoration: none;
+        color: #34345C!important;
+    }
+    #globalToggle {
+        width: 200px;
+        display: inline;
+        text-align: center;
+        margin: 0 auto;
+        margin-bottom: 10px;
+    }
+    .redButton {
+        background-color: #ffadad;
+        background-image: url(/image/buttonfade-red.png);
+        border: 1px solid #C45858;
+        color: #800!important;
+    }
+    div.mPagelist span {
+        padding-left: 3px;
+        padding-right: 3px;
+        font-size: larger;
+    }
+    .button:hover {
+        cursor: pointer;
+    }
+    .mobileCatalogLink,
+    div.absBotText {
+        margin-top: 10px;
+    }
+    .mobileCatalogLink {
+        font-size: larger;
+    }
+    #disable-mobile {
+        font-size: small!important;
+    }
+    #enable-mobile {
+        font-size: small!important;
+        display: none;
+    }
+    .absBotDisclaimer {
+        display: none!important;
+    }
+    div#boardNavMobile {
+        padding: 2px 4px;
+        background-color: #D6DAF0;
+        overflow: hidden;
+        border-bottom: 2px solid #B7C5D9;
+        position: fixed;
+        top: 0px;
+        width: 100%;
+        font-size: x-small;
+    }
+    div#boardNavMobile select,
+    div#boardNavMobile option {
+        font-size: x-small;
+    }
+    div.boardSelect {
+        float: left;
+    }
+    div.boardSelect>strong {
+        padding-right: 5px;
+    }
+    div.pageJump {
+        float: right;
+        padding-right: 5px;
+        padding-top: 3px;
+        font-size: 7.5pt;
+    }
+    .pageJump a {
+        text-decoration: none;
+        padding-right: 5px;
+    }
+    div.postingMode {
+        background-color: #e04000;
+        padding: 3px;
+        text-align: center;
+        width: 300px;
+        margin: 0 auto;
+    }
+    div.navLinks {
+        margin-top: 9px!important;
+        margin-bottom: 0px!important;
+        text-align: center;
+    }
+    div.post div.postInfo span.postNum a {
+        text-decoration: none;
+        color: #000000;
+    }
+    a.quoteLink {
+        color: #D00!important;
+    }
+    div.boardBanner {
+        text-align: center;
+        clear: both;
+    }
+    div.boardBanner>img {
+        border: 1px solid #34345C;
+        margin: 5px 0px 5px 0px;
+        height: 50px;
+        width: 150px;
+        max-width: 100%;
+    }
+    div.boardBanner>div.boardTitle {
+        font-family: Tahoma, sans-serif;
+        font-size: 28px;
+        font-weight: bold;
+        letter-spacing: -2px;
+        margin-top: 0px;
+    }
+    div.boardBanner>div.boardSubtitle {
+        font-size: x-small;
+    }
+    div.post div.file .fileThumb img {
+        border: none;
+        float: left;
+    }
+    span.subject {
+        display: block;
+    }
+    hr {
+        border: none;
+        border-top: 1px solid #B7C5D9;
+        height: 0;
+    }
+    .identityIcon {
+        margin-bottom: -3px;
+        height: 16px;
+        width: 16px;
+    }
+    .stickyIcon {
+        margin-bottom: -2px;
+        padding-left: 2px;
+        height: 16px;
+        width: 16px;
+    }
+    .closedIcon {
+        margin-bottom: -2px;
+        margin-left: -1px;
+        height: 16px;
+        width: 16px;
+    }
+    .fileDeleted {
+        height: 13px;
+        width: 172px;
+    }
+    .fileDeletedRes {
+        height: 13px;
+        width: 127px;
+    }
+    .omittedposts,
+    .abbr {
+        color: #070707;
+    }
+    span.spoiler {
+        color: #000!important;
+        background: #000!important;
+    }
+    span.spoiler:hover,
+    span.spoiler:focus {
+        color: #fff!important;
+    }
+    .preview {
+        background-color: #D6DAF0;
+        border: 1px solid #B7C5D9!important;
+        border-right-width: 2px!important;
+        border-bottom-width: 2px!important;
+    }
+    .fileThumb img {
+        width: auto!important;
+        height: auto!important;
+    }
+    div.mPagelist a {
+        text-decoration: none!important;
+    }
+    .pages a {
+        bottom: -1px;
+        position: relative;
+    }
+    td>input[type="text"],
+    td>textarea,
+    td>input[type="password"] {
+        width: 220px!important;
+        margin-right: 0!important;
+    }
+    #captchaFormPart>td>div {
+        width: 310px!important;
+        overflow: hidden;
+        margin: 0 auto;
+    }
+    #postForm {
+        width: auto;
+    }
+    #postForm input[name="sub"] {
+        width: 160px!important;
+    }
+    #postForm input[type="submit"] {
+        width: 60px;
+        padding: 2px 4px 3px 4px;
+        margin: 0px;
+    }
+    #postForm input[type="password"] {
+        width: 70px!important;
+    }
+    td>input {
+        margin-left: 1px;
+    }
+    tr.mobile {
+        display: table-row!important;
+    }
+    tr.mobile td {
+        padding: 5px;
+    }
+    #postForm:not(.hideMobile) {
+        overflow: hidden;
+        margin-top: 20px;
+        display: table;
+    }
+    form[name="post"] {
+        margin: auto;
+        max-width: 100%;
+    }
+    input[type="text"],
+    input[type="password"],
+    textarea {
+        -webkit-appearance: none;
+        -webkit-border-radius: 0;
+    }
+    input:focus,
+    textarea:focus {
+        border: 1px solid #9988EE!important;
+    }
+    iframe[src="about:blank"] {
+        display: none;
+    }
+    a:hover,
+    .posteruid .hand:hover {
+        color: #DD0000!important;
+    }
+    .button a:hover,
+    a.button:hover {
+        color: #34345C!important;
+    }
+    a.redButton:hover,
+    a.redButton:focus {
+        color: #880000!important;
+    }
+    table#recaptcha_table>tbody>tr:first-child>td:nth-child(2) {
+        display: none;
+    }
+    .reply:target,
+    .reply:focus,
+    .reply.highlight {
+        border: 1px solid #B7C5D9!important;
+        background: #D6BAD0!important;
+    }
+    .mFileInfo {
+        padding-top: 5px;
+        text-align: center;
+        color: #707070!important;
+        font-size: 9pt!important;
+        text-decoration: none!important;
+    }
+    a.replylink,
+    div#absbot a {
+        text-decoration: underline!important;
+    }
+    a.replylink:not(:hover),
+    div#absbot a:not(:hover) {
+        color: #34345C!important;
+    }
+    .mobileSpoiler {
+        padding: 2px!important;
+    }
+    #mpostform {
+        text-align: center;
+        margin-top: 10px;
+    }
+    .postInfoM {
+    display: display;
+    }
+}
+    
+}

--- a/css/stylesheets/mobile.css
+++ b/css/stylesheets/mobile.css
@@ -256,6 +256,10 @@
         font-size: 11pt;
         word-wrap: break-word;
         padding: 5px;
+        display: block;
+    }
+    .postMessage {
+        word-break: break-all;
     }
     .omittedposts,
     .abbr {

--- a/css/stylesheets/saguaba.css
+++ b/css/stylesheets/saguaba.css
@@ -48,10 +48,8 @@ hr {
     border-top: 1px solid #D9BFB7;
     height: 0;
 }
-.adminbar {
+.linkBar {
     text-align: right;
-    clear: both;
-    float: right;
 }
 .logo {
     font-family: Tahoma, sans-serif;
@@ -76,7 +74,15 @@ hr {
     text-align: center;
     font-family: Arial, Helvetica, sans-serif;
 }
-.globalnews {
+.globalNews.desktop {
+    align-items: center;
+    text-align: center;
+    color: red;
+    font-weight: 700;
+    font-size: large;
+}
+.globalNewsM {
+    display: none;
     align-items: center;
     text-align: center;
     color: red;
@@ -187,12 +193,10 @@ hr {
     font-family: Arial, Helvetica, sans-serif;
     padding-left: 20px;
 }
-}
-.omittedposts {
-    font-size: 11px;
-    font-family: Arial, Helvetica, sans-serif;
-    color: #666666;
-    font-weight: 800;
+.summary {
+    font-size: 10pt;
+    margin-top: 10px;
+    color: gray;
 }
 .reply {
     background: rgba(240,224,214,0.85);/*#F0E0D6*/
@@ -202,7 +206,7 @@ hr {
     padding: 2px;
 }
 .postMessage {
-    overflow: hidden;
+    display: -webkit-box;
 }
 .post {
     margin: 4px;

--- a/css/stylesheets/saguaba.css
+++ b/css/stylesheets/saguaba.css
@@ -201,6 +201,9 @@ hr {
     display: table;
     padding: 2px;
 }
+.postMessage {
+    overflow: hidden;
+}
 .post {
     margin: 4px;
 }

--- a/css/stylesheets/saguaba.css
+++ b/css/stylesheets/saguaba.css
@@ -71,11 +71,6 @@ hr {
     font-weight: 700;
     width: 100%;
 }
-.postertrip {
-    color: #117743;
-    font-weight: 600;
-    font-size: 12px;
-}
 .headsub {
     color: #666666;
     text-align: center;
@@ -170,11 +165,11 @@ hr {
     font-family: Arial, Helvetica, sans-serif;
     text-decoration: none;
 }
-.filetitle {
+.subject {
     color: #CC1105;
     font-weight: bold;
 }
-.postername {
+.name {
     color: #117743;
     font-weight: bold;
 }
@@ -204,22 +199,12 @@ hr {
     color: #800000;
     font-family: Arial, Helvetica, sans-serif;
 }
-.doubledash {
+.sideArrows {
     color: #B7C5D9;
     float: left;
     margin-right: 2px;
     margin-top: 0px;
     margin-left: 2px;
-}
-.replytitle {
-    font-size: 18px;
-    font-family: Arial, Helvetica, sans-serif;
-    color: #CC1105;
-}
-.commentpostername {
-    font-size: 14px;
-    font-family: Arial, Helvetica, sans-serif;
-    color: #117743;
 }
 .thumbnailmsg {
     font-size: 9px;

--- a/css/stylesheets/saguaba.css
+++ b/css/stylesheets/saguaba.css
@@ -88,9 +88,9 @@ hr {
     text-align: left;
 }
 .postarea { opacity: 0.9; }
-.postarea {} .rules {
-    font-weight: bold;
-    font-family: Arial, Helvetica, sans-serif;
+.postarea {} 
+.rules {
+    /**/
 }
 .postblock {
     background: #EEAA88;
@@ -195,9 +195,14 @@ hr {
     font-weight: 800;
 }
 .reply {
-    background: rgba(240,224,214,0.85); /*#F0E0D6*/
+    background: rgba(240,224,214,0.85);/*#F0E0D6*/
     color: #800000;
     font-family: Arial, Helvetica, sans-serif;
+    display: table;
+    padding: 2px;
+}
+.post {
+    margin: 4px;
 }
 .sideArrows {
     color: #B7C5D9;
@@ -205,6 +210,9 @@ hr {
     margin-right: 2px;
     margin-top: 0px;
     margin-left: 2px;
+}
+.postLink.mobile {
+    display: none;
 }
 .thumbnailmsg {
     font-size: 9px;
@@ -220,12 +228,23 @@ hr {
 .pages td {
     border:none;padding:1px 5px;
 }
+.postInfoM {
+    display: none;
+}
+
 /*Credits: Dynamic Drive CSS Library */
 /*URL: http://www.dynamicdrive.com/style/ */
 
 .gallerycontainer {
     position: relative;
     /*Add a height attribute and set to largest image's height to prevent overlaying*/
+}
+img.postimg {
+    padding: inherit;
+    padding-bottom: 4pt;
+}
+.fileThumb {
+    float: left;
 }
 .thumbnail img {
     border: 1px solid white;

--- a/css/stylesheets/sagurichan.css
+++ b/css/stylesheets/sagurichan.css
@@ -137,6 +137,10 @@ hr {
     color: #0E07B7;
     font-weight: bold;
 }
+.name {
+    color: #117743;
+    font-weight: bold;
+}
 .subject {
     color: #117743;
     font-weight: bold;

--- a/css/stylesheets/sagurichan.css
+++ b/css/stylesheets/sagurichan.css
@@ -50,11 +50,6 @@ hr {
     text-align: center;
     color: #AF0A0F;
 }
-.postertrip {
-    color: #117743;
-    font-weight: 600;
-    font-size: 11pt;
-}
 .theader {
     text-align: center;
     background-color: blue;
@@ -142,9 +137,7 @@ hr {
     color: #0E07B7;
     font-weight: bold;
 }
-
-span.filetitle {}
-.postername {
+.subject {
     color: #117743;
     font-weight: bold;
 }
@@ -180,22 +173,12 @@ span.filetitle {}
     color: #000000;
     font-family: Arial, Helvetica, sans-serif;
 }
-.doubledash {
+.sideArrows {
     color: #B7C5D9;
     float: left;
     margin-right: 2px;
     margin-top: 0px;
     margin-left: 2px;
-}
-.replytitle {
-    font-size: 10pt;
-    font-family: Arial, Helvetica, sans-serif;
-    color: #0F0C5D;
-}
-.commentpostername {
-    font-size: 10pt;
-    font-family: Arial, Helvetica, sans-serif;
-    color: #117743;
 }
 .thumbnailmsg {
     font-size: 9px;

--- a/css/stylesheets/sagurichan.css
+++ b/css/stylesheets/sagurichan.css
@@ -142,7 +142,7 @@ hr {
     font-weight: bold;
 }
 .subject {
-    color: #117743;
+    color: #0F0C5D;
     font-weight: bold;
 }
 .cap.moderator {

--- a/css/stylesheets/sagurichan.css
+++ b/css/stylesheets/sagurichan.css
@@ -11,7 +11,7 @@ form {
     color: grey;
     text-align: center;
 }
-.adminbar {
+.linkBar {
     text-align: right;
 }
 a {
@@ -33,11 +33,6 @@ hr {
     border: none;
     border-top: 1px solid #B7C5D9;
     height: 0;
-}
-.adminbar {
-    text-align: right;
-    clear: both;
-    float: right;
 }
 .logo {
     font-family: Tahoma, sans-serif;
@@ -75,7 +70,15 @@ hr {
     padding: 4px;
     border: 1px solid black;
 }
-.globalnews {
+.globalNews.desktop {
+    align-items: center;
+    text-align: center;
+    color: red;
+    font-weight: 700;
+    font-size: large;
+}
+.globalNewsM {
+    display: none;
     align-items: center;
     text-align: center;
     color: red;
@@ -168,10 +171,10 @@ hr {
     font-family: Arial, Helvetica, sans-serif;
     color: #0F0C5D;
 }
-.omittedposts {
-    font-size: 8pt;
-    font-family: Arial, Helvetica, sans-serif;
-    padding-left: 20px;
+.summary {
+    font-size: 10pt;
+    margin-top: 10px;
+    color: gray;
 }
 .reply {
     background: rgba(214,218,240,0.85); /*#D6DAF0;*/
@@ -181,7 +184,7 @@ hr {
     padding: 2px;
 }
 .postMessage {
-    overflow: hidden;
+    display: -webkit-box;
 }
 .post {
     margin: 4px;

--- a/css/stylesheets/sagurichan.css
+++ b/css/stylesheets/sagurichan.css
@@ -58,8 +58,9 @@ hr {
     width: 100%;
 }
 .postarea { opacity: 0.9; }
-.postarea {} .rules {
-    font-weight: bold;
+.postarea {}
+.rules {
+    /**/
 }
 .postblock {
     background: #EEAA88;
@@ -176,6 +177,14 @@ hr {
     background: rgba(214,218,240,0.85); /*#D6DAF0;*/
     color: #000000;
     font-family: Arial, Helvetica, sans-serif;
+    display: table;
+    padding: 2px;
+}
+.postMessage {
+    overflow: hidden;
+}
+.post {
+    margin: 4px;
 }
 .sideArrows {
     color: #B7C5D9;
@@ -184,6 +193,9 @@ hr {
     margin-top: 0px;
     margin-left: 2px;
 }
+.postLink.mobile {
+    display: none;
+}
 .thumbnailmsg {
     font-size: 9px;
     font-family: inherit;
@@ -191,13 +203,17 @@ hr {
     padding-left: 20px;
 }
 .pages {
-        border:1px solid black;
-        background: rgba(214,218,240,0.85); /*#D6DAF0;*/
-        color:#89A;
+    border:1px solid black;
+    background: rgba(214,218,240,0.85); /*#D6DAF0;*/
+    color:#89A;
 }
 .pages td {
     border:none;padding:1px 5px;
 }
+.postInfoM {
+    display: none;
+}
+
 /*Credits: Dynamic Drive CSS Library */
 /*URL: http://www.dynamicdrive.com/style/ */
 
@@ -208,6 +224,13 @@ hr {
 .thumbnail img {
     border: 1px solid white;
     margin: 0 5px 5px 0;
+}
+img.postimg {
+    padding: inherit;
+    padding-bottom: 4pt;
+}
+.fileThumb {
+    float: left;
 }
 .thumbnail:hover {
     background-color: transparent;

--- a/css/stylesheets/tomorrow.css
+++ b/css/stylesheets/tomorrow.css
@@ -72,11 +72,6 @@ hr {
     font-weight: 700;
     width: 100%;
 }
-.postertrip {
-    color: #117743;
-    font-weight: 600;
-    font-size: 12px;
-}
 .headsub {
     color: inherit;
     text-align: center;
@@ -163,11 +158,11 @@ th {} .row1 {
     font-family: Arial, Helvetica, sans-serif;
     text-decoration: none;
 }
-.filetitle {
+.subject {
     color: #F7ABFF;
     font-weight: bold;
 }
-.postername {
+.name {
     color: #c5c8c6;
     font-weight: bold;
 }
@@ -201,26 +196,12 @@ th {} .row1 {
     Helvetica,
     sans-serif;
 }
-.doubledash {
+.sideArrows {
     color: #B7C5D9;
     float: left;
     margin-right: 2px;
     margin-top: 0px;
     margin-left: 2px;
-}
-.replytitle {
-    font-size:18px;
-    font-family: Arial,
-    Helvetica,
-    sans-serif;
-    color:#CC1105;
-}
-.commentpostername {
-    font-size:14px;
-    font-family: Arial,
-    Helvetica,
-    sans-serif;
-    color:#117743;
 }
 .thumbnailmsg {
     font-size:9px;

--- a/css/stylesheets/tomorrow.css
+++ b/css/stylesheets/tomorrow.css
@@ -197,6 +197,9 @@ th {} .row1 {
     display: table;
     padding: 2px;
 }
+.postMessage {
+    overflow: hidden;
+}
 .post {
     margin: 4px;
 }

--- a/css/stylesheets/tomorrow.css
+++ b/css/stylesheets/tomorrow.css
@@ -48,10 +48,8 @@ hr {
     border-top: 1px solid #D9BFB7;
     height: 0;
 }
-.adminbar {
+.linkBar {
     text-align: right;
-    clear: both;
-    float: right;
 }
 .logo {
     font-family: Tahoma, sans-serif;
@@ -76,7 +74,15 @@ hr {
     color: inherit;
     text-align: center;
 }
-.globalnews {
+.globalNews.desktop {
+    align-items: center;
+    text-align: center;
+    color: red;
+    font-weight: 700;
+    font-size: large;
+}
+.globalNewsM {
+    display: none;
     align-items: center;
     text-align: center;
     color: red;
@@ -181,14 +187,10 @@ th {} .row1 {
     font-family: Arial, Helvetica, sans-serif;
     padding-left: 20px;
 }
-}
-.omittedposts {
-    font-size:11px;
-    font-family: Arial,
-    Helvetica,
-    sans-serif;
-    color:#666666;
-    font-weight:800;
+.summary {
+    font-size: 10pt;
+    margin-top: 10px;
+    color: gray;
 }
 .reply {
     background: rgba(40,42,46,0.85); /*#282A2E;*/ 
@@ -198,7 +200,7 @@ th {} .row1 {
     padding: 2px;
 }
 .postMessage {
-    overflow: hidden;
+    display: -webkit-box;
 }
 .post {
     margin: 4px;

--- a/css/stylesheets/tomorrow.css
+++ b/css/stylesheets/tomorrow.css
@@ -88,8 +88,9 @@ hr {
     text-align: left;
 }
 .postarea { opacity: 0.9; }
-.postarea {} .rules {
-    font-weight: bold;
+.postarea {} 
+.rules {
+    /**/
 }
 .postblock {
     background: #282A2E;
@@ -192,16 +193,22 @@ th {} .row1 {
 .reply {
     background: rgba(40,42,46,0.85); /*#282A2E;*/ 
     color: inherit;
-    font-family: Arial,
-    Helvetica,
-    sans-serif;
+    font-family: Arial, Helvetica, sans-serif;
+    display: table;
+    padding: 2px;
+}
+.post {
+    margin: 4px;
 }
 .sideArrows {
-    color: #B7C5D9;
+    color: white;
     float: left;
     margin-right: 2px;
     margin-top: 0px;
     margin-left: 2px;
+}
+.postLink.mobile {
+    display: none;
 }
 .thumbnailmsg {
     font-size:9px;
@@ -220,16 +227,26 @@ th {} .row1 {
 .pages td {
     border:none;padding:1px 5px;
 }
+.postInfoM {
+    display: none;
+}
+
 /*Credits: Dynamic Drive CSS Library */
 /*URL: http://www.dynamicdrive.com/style/ */
-
 .gallerycontainer {
     position: relative;
     /*Add a height attribute and set to largest image's height to prevent overlaying*/
 }
+img.postimg {
+    padding: inherit;
+    padding-bottom: 4pt;
+}
 .thumbnail img {
     border: 1px solid white;
     margin: 0 5px 5px 0;
+}
+.fileThumb {
+    float: left;
 }
 .thumbnail:hover {
     background-color: transparent;

--- a/plugins/bgmod.js
+++ b/plugins/bgmod.js
@@ -1,0 +1,21 @@
+$(document).ready(function() {
+    $(".filesize").click(function(e) {
+        e.preventDefault();
+        bgmod_save($(this).find("a").attr('href'));
+        bgmod_set();
+    });
+    
+    function bgmod_save(a) {
+        localStorage['bgmod_url'] = a;
+    }
+    
+    function bgmod_set() {
+        if (localStorage['bgmod_url']) {
+            $.get(localStorage['bgmod_url'])
+            .success(function() { $("body").css({"background": "#FFF url('" + localStorage['bgmod_url'] + "') center/cover no-repeat fixed"}) })
+            .fail(function() { localStorage.removeItem('bgmod_url'); });
+        }
+    }
+    
+    bgmod_set();
+});

--- a/plugins/force_post_wrap.js
+++ b/plugins/force_post_wrap.js
@@ -1,0 +1,20 @@
+//RePod - Forces long posts to wrap at 75% of total page width instead of 100%.
+$(document).ready(function() { repod.post_wrap.init(); });
+try { repod; } catch(e) { repod = {}; }
+repod.post_wrap = { 
+	init: function() {
+		repod.thread_updater && repod.thread_updater.callme.push(repod.post_wrap.update);
+		repod.infinite_scroll && repod.infinite_scroll.callme.push(repod.post_wrap.update);
+		this.config = {
+			enabled: repod.suite_settings && !!repod_jsuite_getCookie("repod_force_post_wrap") ? repod_jsuite_getCookie("repod_force_post_wrap") === "true" : true,
+			selector: ".reply"
+		}
+		repod.suite_settings && repod.suite_settings.info.push({menu:{category:'Miscellaneous',read:this.config.enabled,variable:'repod_force_post_wrap',label:'Force long posts to wrap',hover:'Long posts will wrap at 75\% screen width'}});
+		this.update();
+	},
+	update: function() {
+		if (repod.post_wrap.config.enabled) {
+			$(repod.post_wrap.config.selector).parent().parent().parent().css("max-width","75%");
+		}
+	}
+};

--- a/plugins/jquery/styleswitch.js
+++ b/plugins/jquery/styleswitch.js
@@ -3,8 +3,8 @@ try { repod; } catch(e) { repod = {}; }
 
 repod.styleswitch = {
     init: function() {
-        this.stylesheet_cache = $("link[rel$=stylesheet]"); //Eventually change to a safer selector.
-
+        this.stylesheet_cache = $("link[rel$=stylesheet].togglesheet"); //Eventually change to a safer selector.
+        
         //$("#switchform").remove(); //Literally removing the competition
 
         this.ready();

--- a/plugins/jquery/suite_settings.js
+++ b/plugins/jquery/suite_settings.js
@@ -9,7 +9,7 @@ repod.suite_settings = {
 			//At the moment multi_suffix isn't applied. The suffix applied is hard coded to "amount".
 			pre_categories: ["Images","Quotes & Replying","Monitoring","Navigation","Miscellaneous"] //Categories that should be spawned in this order before everything else.
 		}
-		$("span.adminbar").prepend("[<a href='#' id='repod_jquery_suite_settings_open'>Settings</a>]");
+		$("div.linkBar").prepend("[<a href='#' id='repod_jquery_suite_settings_open'>Settings</a>]");
 		$("a#repod_jquery_suite_settings_open").click(function() { repod.suite_settings.spawn.settings_window(); });
 	},
 	spawn: {


### PR DESCRIPTION
**ADDED IN PULL:**

~~Although it keeps the original, disgusting table usage for thread~~ This pull revamps html layout for every page. This switches Saguaro from the old futallaby table based page system to a css+div system with class name for individual elements.

**Supported stylesheets so far are Sagurichan, Saguaba and Tomorrow.**

_Burichan, kusaba, and monotone are no longer supported. This update breaks those stylesheets._

Futallaby-esque and unused elements have been removed from the page.

**To-do**

<hr>
- [x] Index/thread rewriting
- [x] Mobile display
  - [x] Images expand properly
  - [ ] Mobile theme compatible with current supported theme **As of 10-14, only Sagurichan is supported** 
- [x] _head.php_ rewritten
  - [ ] Mobile support
- [x] _foot.php_ rewritten
  - [ ] Mobile support
