### PR TITLE
Patches remaining Mobile/Desktop CSS issues

### DIFF
--- a/_core/general/head.php
+++ b/_core/general/head.php
@@ -53,9 +53,8 @@ class Head {
             <link class='togglesheet' rel='stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS2 . "' title='Sagurichan' />
             <link class='togglesheet' rel='alternate stylesheet' type='text/css' href='" . CSS_PATH . CSS1 . "' title='Saguaba' />";
         }
-       
+       //<link class='togglesheet' rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS4 . "' title='Burichan'/> RIP Burichan 1862-2015
        $dat  .= "<link class='togglesheet' rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS3 . "' title='Tomorrow' />
-                <link class='togglesheet' rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS4 . "' title='Burichan'/>
                 <script src='" . JS_PATH . "/jquery.min.js' type='text/javascript'></script>
                 <script src='" . JS_PATH . "/styleswitch.js' type='text/javascript'></script>
                 <script src='" . JS_PATH . "/main.js' type='text/javascript'></script>";

--- a/_core/thread/image.php
+++ b/_core/thread/image.php
@@ -52,13 +52,13 @@ class Image {
                 $imgsrc = "<br><a href='" . $displaysrc . "' target='_blank'><img src='" . CSS_PATH . "/imgs/spoiler.png' border='0' align='left' hspace='20' alt='" . $size . "B' md5='$shortmd5'></a>";
             } elseif ( $tn_w && $tn_h ) { //when there is size...
                 if ( @is_file( THUMB_DIR . $tim . 's.jpg' ) ) {
-                    $imgsrc = "<br><a href='" . $displaysrc . "' target='_blank'><img class='postimg' src='" . $thumbdir . $tim . 's.jpg' . "'  style='margin:0px 20px;' width='$tn_w' height='$tn_h' alt='" . $size . "B' md5='$shortmd5'></a>";
+                    $imgsrc = "<br><a href='" . $displaysrc . "' target='_blank'><img class='postimg' src='" . $thumbdir . $tim . 's.jpg' . "' style='margin: 0px 20px;' width='$tn_w' height='$tn_h'' alt='" . $size . "B' md5='$shortmd5'></a>";
                 } else {
                     $imgsrc = "<a href='" . $displaysrc . "' target='_blank'><span class='tn_thread' title='" . $size . "B'>Thumbnail unavailable</span></a>";
                 }
             } else {
                 if ( @is_file( THUMB_DIR . $tim . 's.jpg' ) ) {
-                    $imgsrc = "<br><a href='" . $displaysrc . "' target='_blank'><img class='postimg' src='" . $thumbdir . $tim . 's.jpg' . "' style='margin:0px 20px;' alt='" . $size . "B' md5='$shortmd5'></a>";
+                    $imgsrc = "<br><a href='" . $displaysrc . "' target='_blank'><img class='postimg' src='" . $thumbdir . $tim . 's.jpg' . "' style='margin: 0px 20px;' alt='" . $size . "B' md5='$shortmd5'></a>";
                 } else {
                     $imgsrc = "<a href='" . $displaysrc . "' target='_blank'><span class='tn_thread' title='" . $size . "B'>Thumbnail unavailable</span></a>";
                 }

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -40,6 +40,7 @@ class Post {
         $com = $this->auto_link($com, $no);
 
         $temp .= "<br>";
+        $temp .= ($com == "") ? "<blockquote style='display:none;' class='postMessage' id='m$no' >$com</blockquote>" : "<blockquote class='postMessage' id='m$no' >$com</blockquote>";
         $temp .= "<blockquote class='postMessage' id='m$no' >$com</blockquote>";
         $temp .= "</div></div>";
         return $temp;

--- a/config.php
+++ b/config.php
@@ -118,7 +118,7 @@ define(USE_EXTRAS, 1);      //Automatically include all .js files in JS_PATH/ext
 define(CSS1, '/stylesheets/saguaba.css');    //location of the first stylesheet.
 define(CSS2, '/stylesheets/sagurichan.css'); //location of the second stylesheet.
 define(CSS3, '/stylesheets/tomorrow.css');   //location of the third stylesheet.
-define(CSS4, '/stylesheets/burichan.css');   //location of the fourth stylesheet.
+//define(CSS4, '/stylesheets/CHANGEME.css');   //location of the fourth stylesheet.
 
 define(EXTRA_SHIT, ''); //Any extra javascripts you want to include inside the <head>
 

--- a/css/stylesheets/mobile.css
+++ b/css/stylesheets/mobile.css
@@ -254,12 +254,8 @@
     }
     blockquote.postMessage {
         font-size: 11pt;
-        word-wrap: break-word;
         padding: 5px;
         display: block;
-    }
-    .postMessage {
-        word-break: break-all;
     }
     .omittedposts,
     .abbr {

--- a/css/stylesheets/saguaba.css
+++ b/css/stylesheets/saguaba.css
@@ -205,9 +205,6 @@ hr {
     display: table;
     padding: 2px;
 }
-.postMessage {
-    display: -webkit-box;
-}
 .post {
     margin: 4px;
 }
@@ -249,6 +246,7 @@ hr {
 img.postimg {
     padding: inherit;
     padding-bottom: 4pt;
+    float: left;
 }
 .fileThumb {
     float: left;

--- a/css/stylesheets/sagurichan.css
+++ b/css/stylesheets/sagurichan.css
@@ -183,9 +183,6 @@ hr {
     display: table;
     padding: 2px;
 }
-.postMessage {
-    display: -webkit-box;
-}
 .post {
     margin: 4px;
 }
@@ -231,6 +228,7 @@ hr {
 img.postimg {
     padding: inherit;
     padding-bottom: 4pt;
+    float: left;
 }
 .fileThumb {
     float: left;

--- a/css/stylesheets/tomorrow.css
+++ b/css/stylesheets/tomorrow.css
@@ -62,13 +62,11 @@ hr {
     text-align: center;
     color: inherit;
 }
-}
 .theader {
     text-align: center;
-    background-color: orange;
-    color: white;
+    background-color: #C5C8C6;
+    color: black;
     font-weight: 700;
-    width: 100%;
 }
 .headsub {
     color: inherit;

--- a/css/stylesheets/tomorrow.css
+++ b/css/stylesheets/tomorrow.css
@@ -199,9 +199,6 @@ th {} .row1 {
     display: table;
     padding: 2px;
 }
-.postMessage {
-    display: -webkit-box;
-}
 .post {
     margin: 4px;
 }
@@ -245,6 +242,7 @@ th {} .row1 {
 img.postimg {
     padding: inherit;
     padding-bottom: 4pt;
+    float: left;
 }
 .thumbnail img {
     border: 1px solid white;


### PR DESCRIPTION
Fixes (adds a float) float issues with images. 
Mobile comments wrap properly around images now.
Removed legacy futallaby HTML4 <img> in-tag styling.
Disables Burichan
    - (note: Burichan, Futaba, Monotone and kusaba all still exist in **/stylesheets**
Maybe I'll update Monotone/Kusaba the same time I update Futaba/Burichan. Maybe.
