### PR TITLE
Event stickies

### DIFF
--- a/_core/admin/modifyPost.php
+++ b/_core/admin/modifyPost.php
@@ -5,6 +5,12 @@ class Modify {
     function mod($no, $action = 'none') {
 
         switch ($action) {
+            case 'eventsticky':
+                $sqlValue = "sticky";
+                $rootnum  = "2027-07-07 00:00:00";
+                $sqlBool  = "'2', root='" . $rootnum . "'";
+                $verb     = "Stuck (event mode) ";
+                break;
             case 'sticky':
                 $sqlValue = "sticky";
                 $rootnum  = "2027-07-07 00:00:00";

--- a/_core/admin/postInfo.php
+++ b/_core/admin/postInfo.php
@@ -192,6 +192,7 @@ class DelTable {
             $temp .= "<form action='admin.php' />
             <tr><td class='postblock'>Action</td><td><input type='hidden' name='mode' value='modipost' /><select name='action' />
             <option value='sticky' />Sticky</option>
+            <option value='eventsticky' />Event sticky</option>
             <option value='unsticky' />Unsticky</option>
             <option value='lock' />Lock</option>
             <option value='unlock' />Unlock</option>

--- a/_core/postform.php
+++ b/_core/postform.php
@@ -74,18 +74,19 @@ class PostForm {
         //File selection
         $temp .= "<tr><td class='postblock' align='left'>" . S_UPLOADFILE . "</td><td><input type='file' name='upfile' accept='image/*|.webm' size='35'>";
 
-        if (NOPICBOX && !SPOILERS)
+        if (NOPICBOX && !SPOILER)
             $temp .= "[<label><input type='checkbox' name='textonly' value='on'>" . S_NOFILE . "</label>]</td></tr>";
 
-        /*if (SPOILERS) //Spoiler checkbox
-            $temp .= "[<label><input type='checkbox' name='spoiler' value='on'>" . S_SPOILERS . "</label>]</td></tr>";
-        else*/
+        if (SPOILER && !NOPICBOX) //Spoiler checkbox
+            $temp .= "[<label><input type='checkbox' name='spoiler' value='spoiler'>" . S_SPOILERS . "</label>]</td></tr>";
+        else
             $temp .= "</td></tr>";
 
         if ($admin) { //Admin-specific posting options
             $temp .= "<tr><td align='left' class='postblock' align='left'>
                 Options</td><td align='left'>
                 Sticky: <input type='checkbox' name='isSticky' value='isSticky'>
+                Event sticky: <input type='checkbox' name='eventSticky' value='eventSticky'>
                 Lock:<input type='checkbox' name='isLocked' value='isLocked'>
                 Capcode:<input type='checkbox' name='showCap' value='showCap'>
                 <tr><td class='postblock' align='left'>" . S_RESNUM . "</td><td align='left'><input type='text' name='resto' size='28'></td></tr>";

--- a/_core/regist/prune_old.php
+++ b/_core/regist/prune_old.php
@@ -2,7 +2,10 @@
 
 /*
 
-    This prunes old posts that are pushed off the bottom of last page, called once after each post is made in regist()
+    prune_old(): cleans up posts that are pushed off the bottom of last page, called once after each post is made in regist()
+    
+    pruneThread($no): Targets a specific thread, event stickies where once a certain 
+    number of replies are posted, oldest posts in the thread are automatically deleted.
 
     Used exclusively by regist();
 
@@ -65,6 +68,20 @@ function prune_old() {
             mysql_free_result($result);
         }
     }
+}
+
+function pruneThread($no) {
+    global $my_log;
+    $my_log->update_cache();
+    $maxreplies = EVENT_STICKY_RES;
+
+    $result      = mysql_call("SELECT no FROM " . SQLLOG . " WHERE resto='$no' ORDER BY time ASC");
+    $repcount = mysql_num_rows($result);
+    while ($row = mysql_fetch_array($result) and $repcount >= $maxreplies) {
+        delete_post($row['no'], 'trim', 0, 1, 0, 0); // imgonly=0, automatic=1, children=1
+        $repcount--;
+    }
+    mysql_free_result($result);
 }
 
 ?>

--- a/_core/regist/regist.php
+++ b/_core/regist/regist.php
@@ -287,7 +287,7 @@ if ($resto) { //sage or age action
     $resline = $mysql->query("select sticky,permasage from " . SQLLOG . " where no=" . $resto);
     list($sticky, $permasage) = mysql_fetch_row($resline);
     mysql_free_result($resline);
-    if ((stripos($clean['email'], 'sage') === FALSE && $countres < MAX_RES && $sticky < "1" && $permasage != "1") || ($admin && $age && $sticky < "1")) {
+    if ((stripos($clean['email'], 'sage') === FALSE && $countres < MAX_RES && $sticky < "0" && $permasage != "1") || ($admin && $age && $sticky < "0")) {
         $query = "update " . SQLLOG . " set root=now() where no=$resto"; //age
         $mysql->query($query);
     }

--- a/_core/regist/regist.php
+++ b/_core/regist/regist.php
@@ -287,11 +287,15 @@ if ($resto) { //sage or age action
     $resline = $mysql->query("select sticky,permasage from " . SQLLOG . " where no=" . $resto);
     list($sticky, $permasage) = mysql_fetch_row($resline);
     mysql_free_result($resline);
-    if ((stripos($clean['email'], 'sage') === FALSE && $countres < MAX_RES && $sticky != "1" && $permasage != "1") || ($admin && $age && $sticky != "1")) {
+    if ((stripos($clean['email'], 'sage') === FALSE && $countres < MAX_RES && $sticky < "1" && $permasage != "1") || ($admin && $age && $sticky < "1")) {
         $query = "update " . SQLLOG . " set root=now() where no=$resto"; //age
         $mysql->query($query);
     }
 }
+
+/*if (SPOILER && isset($spoiler));
+    $tim = "Spoiler Image"; //Save tim (thumbnail image) as spoiler image
+    */
 
 //Main insert
 $query = "insert into " . SQLLOG . " (now,name,email,sub,com,host,pwd,ext,w,h,tn_w,tn_h,tim,time,md5,fsize,fname,sticky,permasage,locked,root,resto) values (" . "'" . $now . "'," . "'" . mysql_real_escape_string($clean['name']) . "'," . "'" . mysql_real_escape_string($clean['email']) . "'," . "'" . mysql_real_escape_string($clean['sub']) . "'," . "'" . mysql_real_escape_string($clean['com']) . "'," . "'" . mysql_real_escape_string($host) . "'," . "'" . mysql_real_escape_string($pass) . "'," . "'" . $ext . "'," . (int) $W . "," . (int) $H . "," . (int) $TN_W . "," . (int) $TN_H . "," . "'" . $tim . "'," . (int) $time . "," . "'" . $md5 . "'," . (int) $fsize . "," . "'" . mysql_real_escape_string($upfile_name) . "'," . (int) $stickied . "," . (int) $permasage . "," . (int) $locked . "," . $rootqu . "," . (int) mysql_real_escape_string($resto) . ")";
@@ -324,7 +328,7 @@ if (!$resto) {
 // thumbnail
 if ($has_image) {
     rename($dest, $path . $tim . $ext);
-    if (USE_THUMB) {
+    if (USE_THUMB) { //We'll still make the thumbnail even if its a spoiler image for user extensions.
         require_once("thumb.php");
         $tn_name = thumb($path, $tim, $ext, $resto);
         if (!$tn_name && $ext != ".pdf") {

--- a/_core/regist/regist.php
+++ b/_core/regist/regist.php
@@ -33,8 +33,11 @@ if (valid('moderator')) {
 }
 
 if ($moderator) {
-    if (isset($_POST['isSticky']))
+    if (isset($_POST['isSticky'])) {
         $stickied = 1;
+        if (isset($_POST['eventSticky'])) //Experimental feature.
+            $stickied = 2;
+    }
     if (isset($_POST['isLocked']))
         $locked = 1;
 }
@@ -309,6 +312,13 @@ setcookie("" . SITE_ROOT . "_pass", $c_pass, time() + 7 * 24 * 3600, '/', $cooki
 if (!$resto) {
     require_once('prune_old.php');
     prune_old();
+} else {//Event stickies
+    $eventStick = $mysql->query("SELECT sticky FROM " . SQLLOG . " WHERE no='$resto' AND sticky=2");
+    if (mysql_num_rows($eventStick) > 0) {
+        require_once('prune_old.php');
+        pruneThread($resto);
+    }
+    mysql_free_result($eventStick);
 }
 
 // thumbnail

--- a/config.php
+++ b/config.php
@@ -60,6 +60,9 @@ define(SHOW_BLOTTER, false);      //Added to the top of each board, ex: ex: http
 define(BLOTTER_PATH, 'CHANGEME'); //Absolute html path to your blotter file, this feature is experimental and still is not fully functional.
 
 // Post & Thread
+define(EVENT_STICKY_RES, 1500); //The number of replies allowed to an event sticky before self-pruning begins. 
+//These stickies self delete the oldest posts once the number of replies exceeds this amount.
+
 define(USE_BBCODE, false);  //Use BBcode
 define(DICE_ROLL, false);   //Allow users to roll /dice in the name field
 define(FORTUNE_TRIP, false); //Allows users to recieve a #fortune in the namefield

--- a/config.php
+++ b/config.php
@@ -4,14 +4,15 @@
 */
 
 define(LANGUAGE, 'en-us');                      //Language to use. See "lang" folder for available languages.
-define(TITLE, 'Saguaro beta!');                 //Name of the board.
+define(TITLE, 'Saguaro Imageboard!');                 //Name of the board.
 define(S_HEADSUB, 'No artificial sweeteners!'); //Board subtitle.
 define(S_DESCR, 'An imageboard powered by saguaro'); //meta description for this board
 
 
 /*
     MySQL information.
-    The database and tables are created automatically using these values.
+    The database and tables are created automatically using these values. 
+    Scroll below to the  MySQL Advanced section for futher options 
 */
 define(SQLUSER, 'username');
 define(SQLPASS, 'password');
@@ -25,11 +26,11 @@ define(PREFIX, 'imgboard'); //Prefix to automatically use for the database table
     Something descriptive.
 */
 
-define(PANEL_PASS, 'CHANGEME');  //Janitor password  (CHANGE THIS YO)
-define(SITE_ROOT, 'mysite.com'); //simplified site domain ONLY, EX: saguaro.org
-define(SITE_SUFFIX, '');         //Domain suffix, ex: org, com, info, net. NO DOTS, ONLY LETTERS
+define(PANEL_PASS, 'CHANGEME');  //Staff action key  (CHANGE THIS YO)
+define(SITE_ROOT, 'mysite.com'); //simplified site domain ONLY (subdomains required if used), EX: saguaro.org | EX: boards.saguaro.org 
+define(SITE_SUFFIX, '');         //Domain suffix, ex: org, com, info, net, etc. NO DOTS, ONLY LETTERS
 define(BOARDLIST, '');           //the text file that contains your boardlist, displayed at both header and footer [a/b/c/][d/e/f/] etc.
-define(GLOBAL_NEWS, 'CHANGEME'); //Absolute html path to your global board news file, the contents of this file will be automatically
+define(GLOBAL_NEWS, 'CHANGEME'); //Absolute html path to your global board news file. Appears below post form, above index body
 define(SALTFILE, 'salt');        //Name of the salt file, do not add a file extension for security
 
 //Basic settings
@@ -56,13 +57,10 @@ define(PAGE_DEF, 10); //Threads per page.
 define(PAGE_MAX, 10); //Maximum number of pages, posts that are pushed past the last page are deleted.
 define(LOG_MAX,  1500); //Maximum number of posts to store in the table.
 define(UPDATE_THROTTLING, false); //Leave this as 0 unless you recieve /a lot/ of traffic
-define(SHOW_BLOTTER, false);      //Added to the top of each board, ex: ex: http://yoursite.com/resources/globalnews.txt
-define(BLOTTER_PATH, 'CHANGEME'); //Absolute html path to your blotter file, this feature is experimental and still is not fully functional.
+define(SHOW_BLOTTER, false);      //Experimental. Added to the top of each board, ex: ex: http://yoursite.com/resources/globalnews.txt
+define(BLOTTER_PATH, 'CHANGEME'); //Experimental. Absolute html path to your blotter file, this feature is experimental and still is not fully functional.
 
 // Post & Thread
-define(EVENT_STICKY_RES, 1500); //The number of replies allowed to an event sticky before self-pruning begins. 
-//These stickies self delete the oldest posts once the number of replies exceeds this amount.
-
 define(USE_BBCODE, false);  //Use BBcode
 define(DICE_ROLL, false);   //Allow users to roll /dice in the name field
 define(FORTUNE_TRIP, false); //Allows users to recieve a #fortune in the namefield
@@ -80,34 +78,35 @@ define(PROXY_CHECK, true);  //Enable proxy check.
 define(RENZOKU, 10);        //Seconds between posts (floodcheck)
 define(RENZOKU2, 15);       //Seconds between image posts (floodcheck)
 define(MAX_RES, 500);       //Maximum thread bumps from posts.
-define(MAX_IMGRES, 300);    //Maximum thread bumps from images.
+define(MAX_IMGRES, 300);    //Maximum thread bumps from images
+define(EVENT_STICKY_RES, 1500); //The number of replies allowed to an event sticky before in-thread pruning begins. These stickies self delete the oldest posts once the number of replies exceeds this number.
 define(S_OMITT_NUM, 5);     //number of posts to display in each thread on the index.
-//Is this even referenced?! define(MANTHUMBS, '1');                                 //Display thumbnails in manager panel- you may want it off if you have too many images (1: yes  0: no)
 
 //Captcha
 define(BOTCHECK, false);    //Use CAPTCHAs
-define(RECAPTCHA, TRUE); //Use reCaptcha instead of the default captcha. Requires the SITEKEY and SECRET to be set below.
-define(RECAPTCHA_SITEKEY, "6LcP0Q0TAAAAAM4fwFHpj_v5Vipqdyq68EIuKHwF");//reCaptcha public key.
-define(RECAPTCHA_SECRET, "6LcP0Q0TAAAAAIDvwraDbiPIQD28DfDTvbIHalLZ");//reCaptcha secret key.
+define(RECAPTCHA, false); //Use reCaptcha instead of the default captcha. Requires the SITEKEY and SECRET to be set below.
+define(RECAPTCHA_SITEKEY, "");//reCaptcha public key.
+define(RECAPTCHA_SECRET, "");//reCaptcha secret key.
 
 //Images
 define(DUPE_CHECK, true); //whether or not to check for duplicate images
-define(MAX_KB, 2048); //Maximum upload size in KB
+define(MAX_KB, 3072); //Maximum upload size in KB
 
 //WebM
+define(ALLOW_WEBMS, false); //This feature currently has prequisites. Please visit https://github.com/spootTheLousy/saguaro/wiki/Supporting-WEBMs before enabling.
 define(ALLOW_AUDIO, false); //If true, allows WebMs containing an audio stream.
 define(MAX_DURATION, 60);   //The maximum duration allowed in seconds.
 
-//RePod's JS suite
+//RePod's JS suite. The majority of these should remain disabled until the suite is updated (as of 11-14-15)
 define(USE_JS_SETTINGS, 1); //Include the JS suite's settings - enables user side settings
 define(USE_IMG_HOVER, 1);   //Use image expansion on hover
 define(USE_IMG_TOOLBAR, 0); //Use the image search toolbars
 define(USE_IMG_EXP, 1);     //Use image expansion
-define(USE_UTIL_QUOTE, 1);  //Use utility quotes
+define(USE_UTIL_QUOTE, 0);  //Use utility quotes
 define(USE_INF_SCROLL, 0);  //Use infinite scroll
 define(USE_FORCE_WRAP, 1);  //Use forced post wrapping
-define(USE_UPDATER, 1);     //Use thread updater
-define(USE_THREAD_STATS, 1); //Use thread stats
+define(USE_UPDATER, 0);     //Use thread updater
+define(USE_THREAD_STATS, 0); //Use thread stats
 define(USE_EXTRAS, 1);      //Automatically include all .js files in JS_PATH/extra/
 
 


### PR DESCRIPTION
This is a neat feature, allow admins to create self-pruning stickies. Once a thread reaches a certain number of posts, the oldest replies in the thread are deleted. Useful for running events + browsers that can't handle loading 5000 posts at once

Default config value (`EVENT_STICKY_RES`) is **`1500` posts**

goodnight team
