### PR TITLE
Security improved, allow edit boardlist/news from panel

### DIFF
--- a/_core/admin/news.php
+++ b/_core/admin/news.php
@@ -56,7 +56,7 @@ class News {
         $temp .= "<b>Edit HTML contents of your board list ( " . BOARDLIST . " )<br>";
         $temp .= "<form action='" . PHP_ASELF_ABS . "?mode=editNews' method='post'><input type='hidden' name='file' value='boardlist'><textarea name='update' cols='100' rows='15'/>" . $bl . "</textarea><br><input type='submit' value='Submit'></form>";
         $temp .= "<br><br><hr style='width:40%;'><br>";
-        $temp .= "<b>Edit HTML contents of your board news ( " . GLOBAL_NEWS . " ). For unique board announcements, reference uniuque filepaths in the config. <br>If you want all the board to share an announcement, reference the same filepath in the config.<br>";
+        $temp .= "<b>Edit HTML contents of your board news ( " . GLOBAL_NEWS . " ). For unique board announcements, reference different filepaths in the config. <br>If you want all the boards to share an announcement, reference the same filepath in the config.<br>";
         $temp .= "<form action='" . PHP_ASELF_ABS . "?mode=editNews' method='post'><input type='hidden' name='file' value='globAnno'><textarea name='update' cols='100' rows='15'/>" . $anno . "</textarea><br><input type='submit' value='Submit'></div></form>";
 
         return $temp;

--- a/_core/admin/news.php
+++ b/_core/admin/news.php
@@ -32,7 +32,7 @@ class News {
         return error(S_UPDERR);
     }
     
-    function newsGetFile($file) {
+    private function newsGetFile($file) {
         //Get contents of file, otherwise return error message. 
         if ($file == 1) {
             $get = BOARDLIST;

--- a/_core/admin/news.php
+++ b/_core/admin/news.php
@@ -54,11 +54,12 @@ class News {
         
         $temp = "<br><div class='container' style='text-align:center;'><div class='managerBanner' >Edit Boardlist or Global announcements</div><br><br>";
         $temp .= "<b>Edit HTML contents of your board list ( " . BOARDLIST . " )<br>";
-        $temp .= "<form action='" . PHP_ASELF_ABS . "?mode=editNews' method='post'><input type='hidden' name='file' value='boardlist'><textarea name='update' cols='100' rows='15'/>" . $bl . "</textarea><br><input type='submit' value='Submit'></form>";
+        $temp .= "<form action='" . PHP_ASELF_ABS . "?mode=news' method='post'><input type='hidden' name='file' value='boardlist'><textarea name='update' cols='100' rows='15'/>" . $bl . "</textarea><br><input type='submit' value='Submit'></form>";
         $temp .= "<br><br><hr style='width:40%;'><br>";
         $temp .= "<b>Edit HTML contents of your board news ( " . GLOBAL_NEWS . " ). For unique board announcements, reference different filepaths in the config. <br>If you want all the boards to share an announcement, reference the same filepath in the config.<br>";
-        $temp .= "<form action='" . PHP_ASELF_ABS . "?mode=editNews' method='post'><input type='hidden' name='file' value='globAnno'><textarea name='update' cols='100' rows='15'/>" . $anno . "</textarea><br><input type='submit' value='Submit'></div></form>";
-
+        $temp .= "<form action='" . PHP_ASELF_ABS . "?mode=news' method='post'><input type='hidden' name='file' value='globAnno'><textarea name='update' cols='100' rows='15'/>" . $anno . "</textarea><br><input type='submit' value='Submit'></div></form>";
+        $temp .= "<div class='container' style='text-align:center;'><br><br>You will need to [<a href='?mode=rebuild'>Rebuild</a>] your pages for updates to be visible.</div>";
+        
         return $temp;
         
     }

--- a/_core/admin/news.php
+++ b/_core/admin/news.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+    News class, allows user to modify the contents of their 
+    boardlist/board announcement files from the panel.
+    Could possibly be extended to implement website front pages
+    in the future.    
+    
+    Testing:
+    
+    require_once(CORE_DIR . "/admin/news.php");
+    $news = new News; //lol
+    [Update contents]
+        $news->newsUpdate($bl, $anno);
+    [Get contents]
+        $news->newsGetFile($file);
+    [Display edit panel]
+        $news->newsPanel();
+*/
+
+class News {
+    
+    function newsUpdate($write, $file) {
+    
+    $write = preg_replace('/^<\?php(.*)(\?>)?$/s', '$1', $write); //http://stackoverflow.com/questions/3154644/php-removing-php-tags-from-a-string
+    
+        if ($file === "boardlist")
+            return file_put_contents(BOARDLIST, $write);
+        if ($file === "globAnno");
+            return file_put_contents(GLOBAL_NEWS, $write);
+            
+        return error(S_UPDERR);
+    }
+    
+    function newsGetFile($file) {
+        //Get contents of file, otherwise return error message. 
+        if ($file == 1) {
+            $get = BOARDLIST;
+            return $file = (file_exists($get)) ? file_get_contents(BOARDLIST) : "Board list txtfile not found! Check your config setting for BOARDLIST!";
+        }
+        
+        if ($file == 2)  {
+            $get = GLOBAL_NEWS;
+            return $file = (file_exists($get)) ? file_get_contents(GLOBAL_NEWS) : "Global news txtfile not found! Check your config setting for GLOBAL_NEWS!";
+        }
+        return error(S_UPDERR);
+    }
+    
+    function newsPanel() {
+        //Show the edit panel
+        
+        $bl = $this->newsGetFile(1);
+        $anno = $this->newsGetFile(2);
+        
+        $temp = "<br><div class='container' style='text-align:center;'><div class='managerBanner' >Edit Boardlist or Global announcements</div><br><br>";
+        $temp .= "<b>Edit HTML contents of your board list ( " . BOARDLIST . " )<br>";
+        $temp .= "<form action='" . PHP_ASELF_ABS . "?mode=editNews' method='post'><input type='hidden' name='file' value='boardlist'><textarea name='update' cols='100' rows='15'/>" . $bl . "</textarea><br><input type='submit' value='Submit'></form>";
+        $temp .= "<br><br><hr style='width:40%;'><br>";
+        $temp .= "<b>Edit HTML contents of your board news ( " . GLOBAL_NEWS . " ). For unique board announcements, reference uniuque filepaths in the config. <br>If you want all the board to share an announcement, reference the same filepath in the config.<br>";
+        $temp .= "<form action='" . PHP_ASELF_ABS . "?mode=editNews' method='post'><input type='hidden' name='file' value='globAnno'><textarea name='update' cols='100' rows='15'/>" . $anno . "</textarea><br><input type='submit' value='Submit'></div></form>";
+
+        return $temp;
+        
+    }
+    
+}
+
+?>

--- a/_core/lang/en-us.php
+++ b/_core/lang/en-us.php
@@ -112,6 +112,7 @@ $S_DELRES = 'Deletion mode: Viewing thread #';
 $S_DELALL = 'Deletion mode: All';
 $S_DELIP = 'Deletion mode: Viewing all posts by IP from #';
 $S_DELOPS = 'Deletion mode: All opening posts (OPs)';
+$S_UPDERR = 'File could not be updated!';
 
 //Introducing...new system error strings!
 $E_REGFAILED = 'Post registration failed!';

--- a/_core/page/head.php
+++ b/_core/page/head.php
@@ -146,8 +146,10 @@ class Head {
                 $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=rebuild' >Rebuild all</a>]";
                 $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=reports' >" . $getReport->reportGetAllBoard() . "</a>]";
             }
-            if (valid('admin'))
+            if (valid('admin')) {
                 $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=staff' >Users</a>]";
+                $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=news' >Edit News/Boardlist</a>]";
+            }
             $dat .= "[<a href='" . PHP_ASELF . "?mode=logout'>" . S_LOGOUT . "</a>]";
         }
         return $dat;

--- a/_core/page/head.php
+++ b/_core/page/head.php
@@ -142,8 +142,8 @@ class Head {
             $dat .= "<div class='panelOps' style='text-align:left;' />[<a href=\"" . PHP_SELF2 . "\">" . S_RETURNS . "</a>][<a href=\"" . PHP_SELF . "\">" . S_LOGUPD . "</a>]";
 
             if (valid('moderator')) {
-                $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=all' >Deletion panel</a>]";
                 $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=rebuild' >Rebuild all</a>]";
+                $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=all' >Deletion panel</a>]";
                 $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=reports' >" . $getReport->reportGetAllBoard() . "</a>]";
             }
             if (valid('admin')) {

--- a/admin.php
+++ b/admin.php
@@ -133,6 +133,16 @@ switch ($_GET['mode']) {
         $active    = $getReport->reportGetAllBoard();
         echo $getReport->reportList();
         break;
+    case 'news':
+        head(0);
+        if (!valid('admin'))
+            error(S_NOPERM);
+        require_once(CORE_DIR . "/admin/news.php");
+        $news = new News; //lol
+        if (isset($_POST['update']) && isset($_POST['file']) || isset($_POST['boardlist']))
+            $news->newsUpdate($_POST['update'], $_POST['file']);
+        echo $news->newsPanel();
+        break;
     default:
         head(0);
         aform($post = '', 0, 1);


### PR DESCRIPTION
This is a second, more  secure attempt at
1b06552df7e449f91c26772127295c3764f6aa1c

@RePod is this SECURE enough for you

It strips PHP opening tags and is hardcoded as to what files `newsGetFile()` can access.
