### PR TITLE
Profiler

### DIFF
--- a/_core/page/foot.php
+++ b/_core/page/foot.php
@@ -11,12 +11,14 @@
 
 class Footer {
     function format() {
+        //global $profiler;
+
         $dat = '';
 
         if (file_exists(BOARDLIST))
             $dat .= '<span class="boardlist">' . file_get_contents(BOARDLIST) . '</span>';
 
-        $dat .= '<br><br><div class="footer">' . S_FOOT . '</div><a id="bottom"></a></div></body></html>'; //Last div ends the "afterPosts" class, opened in log.php
+        $dat .= '<br><br><div class="footer">' . S_FOOT . /*'<br>' . $profiler->total() .*/ '</div><a id="bottom"></a></div></body></html>'; //Last div ends the "afterPosts" class, opened in log.php
 
         return $dat;
     }

--- a/_core/profiler/profiler.php
+++ b/_core/profiler/profiler.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+
+    Very basic, and hard to use since most pages are cached and we don't use the Page class enough.
+
+*/
+
+class Profiler {
+    private $stats = [
+        'php' => [],
+        'sql' => []
+    ];
+
+    function init() {
+        $this->stats['php']['start'] = $this->getMicrotime() * -1;
+        $this->stats['sql']['start'] = $this->getSQLcount();
+    }
+
+    function total() {
+        global $mode;
+
+        $php = ($this->getMicrotime() + $this->stats['php']['start']) / 1000;
+        $php = sprintf('%f', $php);
+        $sql = ($this->getSQLcount() - $this->stats['sql']['start']);
+        return "<small>Generated in $php seconds ($sql queries) ($mode)</small>";
+    }
+
+    private function getMicrotime() {
+        return microtime(true);
+    }
+
+    private function getSQLcount() {
+        global $mysql;
+        $blah = $mysql->fetch_assoc("SHOW STATUS WHERE variable_name = 'Queries'");
+        return ((int) $blah['Value']);
+    }
+}
+
+?>


### PR DESCRIPTION
![screenshot_4](https://cloud.githubusercontent.com/assets/7897871/13109769/69be1396-d549-11e5-8bc4-a07bf67b0f6a.jpg)

Basically useless due to page caching and no dynamic pages using the Page class.

Not sure how accurate it is.

Sample integration added (commented out) to _footer.php_ for the Page class.

To start, add it in _imgboard.php_ as early as possible (accurate initial stats) but after MySQL:

``` PHP
require_once(CORE_DIR . "/profiler/profiler.php");
$profiler = new Profiler;
$profiler->init();
```
