### PR TITLE
Bans - The return

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@
 This has been cobbled together from stuff I myself have written and the contributions of others, named in the line I copied and pasted from the old readme just below this one:		
 *"Special thanks to !KNs1o0VDv6, Glas, Anonymous from vchan, RePod, and anyone who actually uses this."*
 
-#License
-While there is no official licensing info due to this being a fork of a fork [...], a lot of great people have worked on saguaro (in spirit) and leaving in credits (specifically in the page's footer, ***S_FOOT***) attributing them is very much appreciated.
-
 #Why use Saguaro?
 Saguaro sports many competitive features not commonly found in other imageboard software:
 - Mobile browser support
@@ -23,7 +20,7 @@ Saguaro sports many competitive features not commonly found in other imageboard 
 - PHP >= 4.2.x (PHP 5 or newer is also recommended)
 - MySQL >= 4.0 
 - GD 2.x
-- libav (avconv/avprobe) for WebMs
+- FFmpeg or libav (avconv) for WebMs
 
 **Additional installation resources:**
 - [Installing](//github.com/spootTheLousy/saguaro/wiki/Installing)
@@ -37,3 +34,6 @@ Saguaro sports many competitive features not commonly found in other imageboard 
 #Testing, Development, and Contributing
 - Setting up a basic [Development Environment](//github.com/spootTheLousy/saguaro/wiki/Development-Environment)
 - [Contributing and standards](//github.com/spootTheLousy/saguaro/wiki/Contributing)
+
+#License
+While there is no official licensing info due to this being a fork of a fork [...], a lot of great people have worked on saguaro (in spirit) and leaving in credits (specifically in the page's footer, ***S_FOOT***) attributing them is very much appreciated.

--- a/_core/admin/bans.php
+++ b/_core/admin/bans.php
@@ -51,7 +51,9 @@ class Banish {
 		if ($this->isBanned($info['host']))
 			die("A ban for this ip already exists");	
 
-		//$row = $mysql->fetch_assoc("SELECT name, com FROM " . SQLLOG . " WHERE no=" . $info['no'] " AND board=" . BOARD_DIR);			
+		$row = $mysql->fetch_assoc("SELECT name, com, now FROM " . SQLLOG . " WHERE no='" . $info['no'] . "' AND board='" . BOARD_DIR ."'");			
+
+        $name = $mysql->escape_string("<span class='name'>" . $row['name'] . '</span> ' . $row['now'] . " No.XXX");
 
 		//Calculate the end time()
 		switch($info['strlength']) {
@@ -113,7 +115,7 @@ class Banish {
         $mysql->query( "INSERT INTO " . SQLBANLOG . " (board, global, name, host, com, reason, length, admin, placed) 
 		VALUES ( '" . BOARD_DIR .
 		"', '" . $info['global'] .
-		"', '" . $row['name'] . 
+		"', '" . $name . 
 		"', '" . $info['host'] .
 		"', '" . $row['com'] . 
 		"', '" . $info['reason'] . 
@@ -242,7 +244,8 @@ class Banish {
             
             if ($info['type'] === 'warned') {
                 $temp = '<div class="container"><div class="header">You have been ' . $info['type'] . '! :~:</div><div class="banBody">';
-                $temp .= '<p>You were ' . $info['type'] . ' for the following reason: </p><br /><p>' . $info['reason'] . '</p><br /><hr />
+                $temp .= '<p>You were ' . $info['type'] . ' for the following reason: </p><br /><p>' . $info['reason'] . '</p><br>
+                        The ban was filed on your post (without image):<br><br> ' . $info['post'] . '<br><hr />
                         <p>This warn was placed on ' . $info['placed'] . '. Now that you have seen it, you should be able to post again. 
                         <p>Please review the board rules and be aware that further rule violations can result in an extended ban.</p><br />                        
                         <br/>This action was filed for the following IP address: ' . $info['host'] . '</div>';
@@ -252,7 +255,8 @@ class Banish {
                 
                 $expired = ($info['append']) ? ". Your ban is now lifted and you should be able to continue posting. Please be review and be mindful of the board rules to prevent future bans" :  ' and will expire on: ' . $info['expires'] . $info['length'];
                 
-                $temp .= '<p>You were ' . $info['type'] . ' for the following reason: </p><br /><p>' . $info['reason'] . '</p><br /><hr />
+                $temp .= '<p>You were ' . $info['type'] . ' for the following reason: </p><br /><p>' . $info['reason'] . ' .</p><br>
+                        The ban was filed on your post (without image):<br><br> ' . $info['post'] . '<br><hr />
                         <p>This ban was placed on ' . $info['placed'] . $expired . '  
                         <br>This action was filed for the following IP address: ' . $info['host'] . '</div>';
                 
@@ -275,7 +279,7 @@ class Banish {
 
 		$row = $mysql->fetch_assoc("SELECT * FROM " . SQLBANLOG . " WHERE host='$host'");
 		
-		$name = "<span class='name'>" . $row['name'] . "</span>";
+		$post = "<span class='post reply'>" . $row['name'] . "<br><blockquote>" . $row['com'] . "</blockquote></span>";
 		$global = ($row['global']) ? "<strong>all boards</strong>" : "<strong>/" . $row['board'] . "/</strong> ";
 		$host = "<span class='bannedHost' >" . $host . "</span>";
 		$reason = "<span class='reason'>" . $row['reason'] . "</span>";
@@ -301,8 +305,8 @@ class Banish {
 		}
 
 		return [
-			'name'		=> $name,
 			'global'	=> $global,
+            'post'       => $post,
 			'board'		=> $row['board'],
 			'host'		=> $host,
 			'reason'	=> $reason,

--- a/_core/admin/bans.php
+++ b/_core/admin/bans.php
@@ -241,7 +241,7 @@ class Banish {
             
             if ($info['type'] === 'warned') {
                 $temp = '<div class="container"><div class="header">You have been ' . $info['type'] . '! :~:</div><div class="banBody">';
-                $temp .= '<p>You were ' . $info['type'] . ' for the following reason: </p><br /><p>' . $info['reason'] . '</p><br>
+                $temp .= '<p>You were ' . $info['type'] . ' for the following reason: </p><p>' . $info['reason'] . '</p><br>
                         The ban was filed on your post (without image):<br><br> ' . $info['post'] . '<br><hr />
                         <p>This warn was placed on ' . $info['placed'] . '. Now that you have seen it, you should be able to post again. 
                         <p>Please review the board rules and be aware that further rule violations can result in an extended ban.</p><br />                        
@@ -252,7 +252,7 @@ class Banish {
                 
                 $expired = ($info['append']) ? ". Your ban is now lifted and you should be able to continue posting. Please be review and be mindful of the board rules to prevent future bans" :  ' and will expire on: ' . $info['expires'] . $info['length'];
                 
-                $temp .= '<p>You were ' . $info['type'] . ' for the following reason: </p><br /><p>' . $info['reason'] . ' .</p><br>
+                $temp .= '<p>You were ' . $info['type'] . ' for the following reason: </p><p>' . $info['reason'] . ' .</p><br>
                         The ban was filed on your post (without image):<br><br> ' . $info['post'] . '<br><hr />
                         <p>This ban was placed on ' . $info['placed'] . $expired . '  
                         <br>This action was filed for the following IP address: ' . $info['host'] . '</div>';
@@ -262,7 +262,7 @@ class Banish {
 		} else {
             $page->headVars['page']['title'] = "You are not banned!";
 			//$page->headVars['css']['extra'] = "banned.css";
-            $temp = '<div class="container"><div class="header">You are not banned!</div><div class="banBody"><br>You are not banned from posting.</div></div>';
+            $temp = '<div class="container"><div class="header">You are not banned!</div><div class="banBody">You are not banned from posting.</div></div>';
             
             return $temp;
         }

--- a/_core/admin/bans.php
+++ b/_core/admin/bans.php
@@ -187,8 +187,8 @@ class Banish {
 		$no = $mysql->escape_string($_GET['no']);
 		
         $host  = $mysql->result("SELECT host FROM " . SQLLOG . " WHERE no='$no'", 0, 0);
-        $alart = ($host) ? $mysql->result("SELECT COUNT(*) FROM " . SQLBANLOG . " WHERE host='" . $host . "'") : 0;
-        $alert = ($alart > 0) ? "<strong><font color=\"FF101A\"> $alart ban(s) on record for $host!</font></b>" : "No bans on record for IP $host";
+        $alart = ($host) ? $mysql->result("SELECT COUNT(*) FROM " . SQLBANNOTES . " WHERE host='" . $host . "'") : 0;
+        $alert = ($alart > 0) ? "<strong><font color=\"FF101A\"> $alart ban(s)/warn(s) on record for $host!</font></b>" : "No bans on record for IP $host";
         
         $temp .= "<!---banning #:$no; host:$host---><br><table border='0' cellpadding='0' cellspacing='0' /><form action='admin.php?mode=ban' method='POST' />
             <input type='hidden' name='no' value='$no' />

--- a/_core/admin/bans.php
+++ b/_core/admin/bans.php
@@ -1,61 +1,112 @@
 <?php
+/*
+
+    ==================================== Saguaro Ban Class ========================================
+    
+        This handles all the fun things ban related.
+        Stores ip information 3 different ways now. Absolutely incredible.
+        
+        Check if a user is banned. If they are, the function will return true. Call with the "redirect" flag to send the user to banned.php.
+        require_once(CORE_DIR . "/admin/bans.php);
+        $bans = new Banish;
+        $bans->isBanned($ip, true); 
+    
+    ==========================================================================================
+    
+*/
+
+
 
 class Banish {
-	
-    function isBanned($ip) {
-		global $mysql;
+    
+    //If user is banned, return true.
+    function isBanned($ip, $redirect = 0) {
+        global $mysql;
+        
+        $query   = $mysql->query("SELECT count(*)>0 FROM " . SQLBANLOG . " WHERE host='$ip' AND active=1 AND (board='$board' or global=1)");
+        $exists = $mysql->result($query, 0, 0);
 
-		$query = "SELECT ip FROM " . SQLBANLOG . " WHERE ip='" . $mysql->escape_string($ip) . "' AND active>0";
-		$result = $mysql->num_rows($query);
+        $respond = ($redirect) ? header("Location: banned.php") : true; //If isbanned is called with redirect, then return the new header
+        return ($exists > 0) ? $respond : false;
+    }
 
-		return ($result > 0) ? true : false;
+
+    function process($no, $ip, $length, $global, $reason, $pubreason) {
+        global $mysql, $my_log;
+
+        //Append public ban message
+        $mysql->query("UPDATE " . SQLLOG . " SET com = CONCAT(com, '<br><b><font color=\"FF101A\">" . $mysql->escape_string($custmess) . "</font></b>') where no='" . $no . "'");
+
+        $my_log->update($no);
+        
+        echo "<script>window.close();</script>"; //Close ban window
+        
+        return true; //Success
     }
     
-	function postOptions($no, $ip, $expires, $expires2, $banType, $perma, $pubreason, $staffnote, $custmess, $showbanmess, $afterban) {
-        global $mysql, $my_log;
-		//This will do the POST processing and pass it to applyBan
-		
-		$str = "+" . $expires . " " . $expires2;
-		$expires = strtotime($str, time() );
-		
-        $custmess = ($showbanmess) ? ($custmess == '') ? "(USER WAS BANNED FOR THIS POST)" : "(" . $custmess . ")" : 0; //pls ignore
+    function autoBan($name, $host, $length, $global, $reason, $pubreason = '') {
+        global $mysql;
+        
+        //Get all IP info for the ban
+        $reverse = $mysql->escape_string(gethostbyaddr($host));
+        $xff     = $mysql->escape_string(getenv("HTTP_X_FORWARDED_FOR"));
+        $host    = $mysql->escape_string($host); //Proceed with tidy host
+        
+        //Already banned, don't insert again
+        if ($this->isBanned($host)) { 
+            Delete::deleteUploaded();
+            die();
+        }
+        
+        if (!$name) $name = S_ANONAME;
+        
+        if (strpos($name, '</span> <span class="postertrip">!') !== FALSE) {
+            $nameparts = explode('</span> <span class="postertrip">!', $name);
+            $name  = "{$nameparts[0]} #{$nameparts[1]}";
+        }        
+        
+        $name  = $mysql->escape_string($name);
+        $global    = ($global) ? 1 : 0;
+        $board     = BOARD_DIR;
+        $reason    = $mysql->escape_string($reason);
+        $pubreason = $mysql->escape_string($pubreason);
 
-        $afterban = (int) $afterban;
-		if ($afterban > 0) {
-            require_once(CORE_DIR . '/admin/delete.php');
-            $del = new Delete;
-			if ($afterban == 1):
-                $del->targeted($no, $pwd, $imgonly = 0, $automatic = 1, $children = 1, $die = 1);
-			elseif ($afterban == 2):
-                $del->targeted($no, $pwd, $imgonly = 1, $automatic = 1, $children = 1, $die = 1);
-			else:
-                $del->targeted($no, $pwd, $imgonly = 0, $automatic = 1, $children = 0, $die = 1, $ip);
-            endif;
-		}
-		
-		$mysql->query( "INSERT INTO " . SQLBANLOG . " (ip, active, placedon, expires, board, type, reason, staffnotes) 
-		VALUES ('" . $mysql->escape_string( $ip ) . "', 
-		'1', 
-		UNIX_TIMESTAMP(),
-		'" . $mysql->escape_string( $expires ) . "',
-		'" . BOARD_DIR . "', 
-		'" . $mysql->escape_string( $banType ) . "', 
-		'" . $mysql->escape_string( $pubreason ) . "', 
-		'" . $mysql->escape_string( $staffnote ) . "' )");
+        if ($pubreason) $pubreason .= "<>";
 
-		if ($custmess)
-			$mysql->query( "UPDATE " . SQLLOG . " SET com = CONCAT(com, '<br><b><font color=\"FF101A\">" . $mysql->escape_string( $custmess ) . "</font></b>') where no='" . $no . "'");  
-	
-        $my_log->update($no);
+        switch($banlength) {
+            case 0:
+                //Auto-warn
+                $autowarnq     = $mysql->query("SELECT COUNT(*) FROM " . SQLLOGBAN . " WHERE host='$host' AND admin='Auto-ban' AND now > DATE_SUB(NOW(),INTERVAL 3 DAY) AND reason like '%$reason'");
+                $autowarncount = $mysql->result($autowarnq, 0, 0);
+                if ($autowarncount > 3) $banlength = 14; //14 days
+                break;
+            case -1:
+                //Permanent
+                $length = '0000' . '00' . '00'; // YYYY/MM/DD
+                break;
+            default:
+                //Normal ban
+                $banlength = (int) $banlength;
+                $length = date("Ymd", time() + $banlength * (24 * 60 * 60));
+                break;
+        }
+
+        $length .= "00" . "00" . "00"; // H:M:S
+
+        if (!$result = $mysql->query("INSERT INTO " . SQLLOGBAN . " (board,global,name,host,reason,length,admin,reverse,xff) VALUES('$board','$global','$name','$host','$pubreason<b>Auto-ban</b>: $reason','$length','Auto-ban','$reverse','$xff')"))
+            echo S_SQLFAIL;
+            
+        @$mysql->free_result($result);
     }
-	
+    
+    //Ban filing form.
     function form($no) {
         global $mysql;
-    
-        $host = $mysql->result("SELECT host FROM " . SQLLOG . " WHERE no='" . $mysql->escape_string($no) . "'", 0, 0);
-        $alart = ($host) ? $mysql->num_rows("SELECT COUNT(*) FROM " . SQLBANLOG . " WHERE ip='" . $host . "'") : 0;
-        $alert = ( $alart > 0) ? "<b><font color=\"FF101A\"> $alart ban(s) on record for $host!</font></b>" : "No bans on record for IP $host";
-
+        
+        $host  = $mysql->result("SELECT host FROM " . SQLLOG . " WHERE no='" . $mysql->escape_string($no) . "'", 0, 0);
+        $alart = ($host) ? $mysql->result("SELECT COUNT(*) FROM " . SQLBANLOG . " WHERE ip='" . $host) : 0;
+        $alert = ($alart > 0) ? "<b><font color=\"FF101A\"> $alart ban(s) on record for $host!</font></b>" : "No bans on record for IP $host";
+        
         $temp = head(1);
         
         $temp .= "<!---banning #:$no; host:$host---><br><table border='0' cellpadding='0' cellspacing='0' /><form action='admin.php?mode=ban' method='POST' />
@@ -71,7 +122,7 @@ class Banish {
                 </select></td></tr>
             <center><tr><td class='postblock'>Ban type:</td><td></center>
                 <select name='banType' />
-                <option value='1' />Warning only</option>
+                <option value='0' />Warning only</option>
                 <option value='2' />This board - /" . BOARD_DIR . "/ </option>
                 <option value='3' />All boards</option>
                 <option value='4' />Permanent - All boards</option>
@@ -88,19 +139,14 @@ class Banish {
                 <option value='3' />Delete all by this IP</option>
                 </select>
             </td></tr>";
-            /*if (valid('admin'))
-                $temp .= "
-                <tr><td class='postblock'>Add to Blacklist:</td><td>[ Comment<input type='checkbox' name='blacklistcom' /> ] [ Image MD5<input type='checkbox' name='blacklistimage' /> ] </td></tr>";*/ //Soon.
-            $temp .= "<center><tr><td><input type='submit' value='Ban'/></td></tr></center></table></form>";
-            
-            echo $temp;
+        /*if (valid('admin'))
+        $temp .= "
+        <tr><td class='postblock'>Add to Blacklist:</td><td>[ Comment<input type='checkbox' name='blacklistcom' /> ] [ Image MD5<input type='checkbox' name='blacklistimage' /> ] </td></tr>";*/ //Soon.
+        $temp .= "<center><tr><td><input type='submit' value='Ban'/></td></tr></center></table></form>";
+        
+        echo $temp;
     }
     
-	function afterBan() {
-		//Display information for ban just executed, allow revert option, redirect to admin.
-		echo "Banned IP: " . $ip . ", Redirecting. <META HTTP-EQUIV=\"refresh\" content=\"2;URL=" . PHP_ASELF_ABS . "\">";
-	}
-	
 }
 
 ?>

--- a/_core/admin/bans.php
+++ b/_core/admin/bans.php
@@ -24,9 +24,7 @@ class Banish {
         global $mysql;
         
         $exists   = $mysql->num_rows("SELECT * FROM " . SQLBANLOG . " WHERE host='$ip' AND (board='" . BOARD_DIR . "' or global=1)");
-
-        $respond = ($redirect) ? header("Location: banned.php") : true; //If isbanned is called with redirect, then return the new header
-        return ($exists > 0) ? $respond : false;
+        return ($exists > 0) ? true : false;
     }
 
     //Files the ban

--- a/_core/admin/bans.php
+++ b/_core/admin/bans.php
@@ -23,8 +23,7 @@ class Banish {
     function isBanned($ip, $redirect = 0) {
         global $mysql;
         
-        $query   = $mysql->query("SELECT count(*)>0 FROM " . SQLBANLOG . " WHERE host='$ip' AND (board='" . BOARD_DIR . "' or global=1)");
-        $exists = $mysql->result($query, 0, 0);
+        $exists   = $mysql->num_rows("SELECT * FROM " . SQLBANLOG . " WHERE host='$ip' AND (board='" . BOARD_DIR . "' or global=1)");
 
         $respond = ($redirect) ? header("Location: banned.php") : true; //If isbanned is called with redirect, then return the new header
         return ($exists > 0) ? $respond : false;

--- a/_core/admin/bans.php
+++ b/_core/admin/bans.php
@@ -146,6 +146,11 @@ class Banish {
         
         echo $temp;
     }
+	
+	function banScreen($info) {
+		//Returns & processes banned.php HTML
+		
+	}
     
 }
 

--- a/_core/admin/delete.php
+++ b/_core/admin/delete.php
@@ -119,5 +119,12 @@ class Delete extends Log {
         
         return $row['resto']; // so the caller can know what pages need to be rebuilt
     }
+    
+    function deleteUploaded($file, $path) {
+        global $upfile, $dest;
+        if ($dest || $upfile) {
+            @unlink($upfile);
+            @unlink($dest);
+    }
 }
 ?>

--- a/_core/admin/delete.php
+++ b/_core/admin/delete.php
@@ -38,7 +38,7 @@ class Delete extends Log {
             $this->update(0, 1); // update the index page last
     }
     
-    function targeted($resno, $pwd, $imgonly = 0, $automatic = 0, $children = 1, $die = 1, $allbyip = 0, $delhost = '') {
+    function targeted($resno, $pwd, $imgonly = 0, $automatic = 0, $children = 1, $die = 1, $delhost = '') {
         global $path, $mysql;
 
         $this->update_cache(1);
@@ -82,9 +82,9 @@ class Delete extends Log {
             $mysql->query("INSERT INTO " . SQLDELLOG . " (admin, postno, action, board,name,sub,com,img) 
             VALUES('$auser','$resno', '$imgonly2', '" . BOARD_DIR . ", '$adname','{$row['sub']}','{$row['com']}')");
         }
-        if ($allbyip && $delhost !== ''): 
+        if ($delhost !== ''): 
             $result = $mysql->query("select no,resto,tim,ext from " . SQLLOG . " where host='" . $delhost . "'");
-        elseif ($row['resto'] == 0 && $children && !$imgonly && !$allbyip): // select thread and children
+        elseif ($row['resto'] == 0 && $children && !$imgonly && !$delhost): // select thread and children
             $result = $mysql->query("select no,resto,tim,ext from " . SQLLOG . " where no=$resno or resto=$resno");
         else: // just select the post
             $result = $mysql->query("select no,resto,tim,ext from " . SQLLOG . " where no=$resno");

--- a/_core/admin/modify.php
+++ b/_core/admin/modify.php
@@ -4,6 +4,8 @@ class Modify {
     function mod($no, $action = 'none') {
         global $mysql;
         
+        $no = $mysql->escape_string($no);
+        
         switch ($action) {
             case 'eventsticky':
                 $sqlValue = "sticky";

--- a/_core/admin/report.php
+++ b/_core/admin/report.php
@@ -1,94 +1,92 @@
 <?php
-
 /*      
-
-        Reports class. 
-        Eventually revisit this to make it do a less obscene amount of mysql calls per report.
-        Perhaps integrate the log cache to cut down on queries.
+    ============================= MEME HEADER ============================= 
+        Saguaro reports class. Handles everything related to.....reports.
+        What the HELL was going on here?
         
+        Cleaned up and optimized. somewhat.
+        Next time on reports rewriting: A log style cache that'll let me do fancier things.
+        
+        Still absolute garbage. The htmlolocaust is coming, heil templates
+    =======================================================================
 */
-
 
 class Report {
     
-    function reportProcess() {
+    function process() {
     	global $mysql;
         if ($_SERVER['REQUEST_METHOD'] == 'GET') {
-            $no = $mysql->escape_string($_GET['no']);
-            //Various checks in the popup window before form is filed
-            $this->reportPostExists($no);
-            $this->reportIsCleared($no);  
-            $this->reportCheckIP(BOARD_DIR, $no, $_SERVER['REMOTE_ADDR']);
-            $this->reportForm(BOARD_DIR, $_GET['no']); //User passed checks, display form
+            //User initiated report window.
+            $this->canSubmit($_GET['no']);
+            $this->showForm($_GET['no']);
         } else {
-            //Report form has been filled out, POST'ed and can now be filed
-            if ($this->reportCheckIP(BOARD_DIR, $no, $_SERVER['REMOTE_ADDR'])) //One last check for people trying to be sneaky.
-                $this->error('Please wait a while before reporting more posts.', $no);
-            $this->reportSubmit(BOARD_DIR, $_POST['no'], $_POST['cat']);
+            //Form popup has been submitted, file it.
+            $this->formSubmit($_POST['no'], $_POST['cat']);
         }
         die('</body></html>');
     }
     
-    function reportGetAllBoard($list = 0) {
+    function countBoard() {
     	global $mysql;
-        $query = $mysql->query(" SELECT * FROM reports WHERE board='" . BOARD_DIR . "' AND type > 0");
         
-        if (!$list) { //If the call is for the oldvalid() alert in admin.php, this will be 1.	
-            $active = $mysql->num_rows($query);
-            if ($active > 0)
-                $active = "<b><font color='red'/>$active Reports!</font></b>";
-            else
-                $active = "Reports";
-        } else {
-            $active = $query;
-        }
+        $query = " SELECT COUNT(*) FROM reports WHERE board='" . BOARD_DIR . "' AND type<>0";
+        $active = $mysql->result($query, 0, 0);
+        $active = ($active) ? "<b><font color='red'/>$active Reports!</font></b>" : "Reports";
+        
         return $active;
     }
     
-    function reportPostExists($no) {
-    	global $mysql;
-    //I won't dignify retards who report stickies with a SQL query, just give them the post not found error.
-        $query = $mysql->query("SELECT * FROM " . SQLLOG . " WHERE no='$no' AND sticky < 1 LIMIT 1");
-        if ($mysql->num_rows($query) < 1)
+    function canSubmit($no) {
+        global $mysql, $my_log;
+
+        $my_log->update_cache(0);
+        $log = $my_log->cache;
+
+        $host = $mysql->escape_string($_SERVER['REMOTE_ADDR']);
+        $no = $mysql->escape_string($no);
+        $board = BOARD_DIR;
+
+        $query = "SELECT * FROM reports WHERE ip='$host' AND board='$board'";
+
+        //Post exists?
+        if (!isset($log[$no]))
             return $this->error("That post doesn't exist.", $no);
-    }
-    
-    function reportIsCleared($no) {
-    	global $mysql;
-        $query = $mysql->query("SELECT `no`,`type` FROM reports WHERE no='" . $no . "' AND type='0' LIMIT 1");
+
+        //Trying to report a sticky?
+        if ($log[$no]['sticky'] > 0) return $this->error("Stop trying to report a sticky!", $no);
+
+        //User is reporting themself?
+        if ($host == $log[$no]['host']) return $this->error("You can't report your own post!", $no);
+
+        //Already reported this ip or is going on a reporting spree?
+        if ($mysql->num_rows($query) > REPORT_FLOOD && !valid('reportflood'))
+            return $this->error('Report flood limit reached.', $no);
+
+        /* Handled in 
+        //Has report been cleared?
+        $query = "SELECT `no`,`type` FROM reports WHERE no='" . $no . "' AND type='0' LIMIT 1";
         if ($mysql->num_rows($query) > 0)
             return $this->error('This post has been reviewed and cleared.', $no);
+        */
+
     }
 
-    function reportClear($no) {
+    function clearNum($no) {
     	global $mysql;
         
         if (!valid('moderator'))
-            $this->error("Permission denied");
+            $this->error(S_NOPERM);
         
         $no = $mysql->escape_string($no);
-        if ($this->reportPostExists($no)) {
-            @$mysql->query("DELETE FROM reports WHERE no='$no'"); //How did you get there? Attempt to clear up the phantom report.
-            $this->error("That report/post doesn't exist anymore!");
-        }
-        //Set report type to inactive if it's been cleared by a mod. 
-        //deletePost.php does the deletion when the post is pruned anyway
-        $mysql->query("UPDATE reports SET type='0' WHERE no='$no'");
-    }
-    
-    function reportCheckIP($board, $no, $ip) {
-    	global $mysql;
-        $query = $mysql->query("SELECT host FROM " . SQLLOG . " WHERE no='$no' AND host='$ip' LIMIT 1");
-        if ($mysql->num_rows($query) > 0) //Trying to report own post
-            return $this->error("You can't report your own post!", $no);
 
-        //Check if the submitting user has already reported this ip or is going on a reporting spree.
-        $query = $mysql->query("SELECT * FROM reports WHERE ip='" . $ip . "' AND board='" . $board . "'");
-        if ($mysql->num_rows($query) > 3 && !valid('janitor_board')) //Relax there, tattle tale
-            return $this->error('Please wait a while before reporting more posts.', $no);
+        //Set report type to *inactive* if it's been cleared by a mod. 
+        // _core/admin/delete.php deletes the report from the queue when the post is removed
+        $mysql->query("UPDATE reports SET type='0' WHERE no='$no'");
+        
+        return true;
     }
     
-    function reportSubmit($board, $no, $type) {
+    function formSubmit($no, $type) {
     	global $mysql;
         require_once(CORE_DIR . "/general/captcha.php");
         $captcha = new Captcha;
@@ -102,19 +100,19 @@ class Report {
         /*cat = 1: Rule violation
         cat = 2: Illegal content
         cat = 3: Advertising
-        0 = Cleared by moderator, can't report it again. 
-        This is not a valid submit option. 
-        If the report isn't submitted with either cat 1,2 or 3, it is discarded */
+        0 = Cleared by moderator, can't report it again*/
+        
+        if ($type == "0") //User is trying to make their post unreportable.
+            $this->error("Invalid post option!", $no);
+        
         $host   = $_SERVER['REMOTE_ADDR'];
-        $cboard = $mysql->escape_string($board);
-        $cno    = $mysql->escape_string($no);
-        $ctype  = $mysql->escape_string($type);
-        $mysql->query("INSERT INTO reports (`num`, `no`, `board`, `type`, `time`, `ip`) VALUES ( '" . rand() . "', '" . $cno . "', '" . $cboard . "', '" . $ctype . "', NOW(), '" . $host . "') ");
+        $no    = $mysql->escape_string($no);
+        $type  = $mysql->escape_string($type);
+        $mysql->query("INSERT INTO reports (`no`, `board`, `type`, `ip`) VALUES ( '" . $no . "', '" . BOARD_DIR . "', '" . $type . "','" . $host . "')");
         
         echo "<head><link rel='stylesheet' type='text/css' href='" . CSS_PATH . "/" . $style . ".css'/><script>function loaded(){window.setTimeout(CloseMe, 3000);}function CloseMe() {window.close();}</script></head><body onLoad='loaded()'>
 	<center><font color=blue size=5>Report submitted! This window will close in 3 seconds...</b></font></center></body>";
     }
-    
     function reportFormHead($no) {
     	global $mysql;
         $style = (NSFW) ? "saguaba" : "sagurichan";
@@ -129,7 +127,7 @@ class Report {
 		</head>';
     }
     
-    function reportForm($board, $no) {
+    function showForm($no) {
     	
         require_once(CORE_DIR . "/general/captcha.php");
         $captcha = new Captcha;
@@ -166,7 +164,7 @@ class Report {
         
     }
     
-    function reportList() {
+    function displayTable() {
         global $mysql;
         if (!$active = $mysql->query(" SELECT * FROM reports WHERE board='" . BOARD_DIR . "' AND type>0 ORDER BY `type` DESC "))
             echo S_SQLFAIL;

--- a/_core/admin/report.php
+++ b/_core/admin/report.php
@@ -165,48 +165,7 @@ class Report {
 		</html>';
         
     }
-    
-    function displayTable() {
-        global $mysql;
-        if (!$active = $mysql->query(" SELECT * FROM reports WHERE board='" . BOARD_DIR . "' AND type>0 ORDER BY `type` DESC "))
-            echo S_SQLFAIL;
-        $j = 0;
-        
-        $temp .= "<br><br><div class='managerBanner'>Active reports for /" . BOARD_DIR . "/ - " . TITLE . "</div>";
-        $temp .= "<table class='postlists'>";
-        $temp .= "<tr class=\"postTable head\"><th>Clear Report</th><th>Post Number</th><th>Board</th><th>Reason</th><th>Reporting IP</th><th>Post info</th>";
-        $temp .= "</tr>";
-        
-        while ($row = $mysql->fetch_array($active)) {
-            $j++;
 
-            switch ($row['type']) {
-                case '1':
-                    $type = 'Spam';
-                    break;
-                case '2':
-                    $type = 'Rule Violation';
-                    break;
-                case '3':
-                    $type = 'Illegal Content';
-                    break;
-                default:
-                    $type = 'Type Error';
-                    break;
-            }
-            $class = ($j % 2) ? "row1" : "row2"; //BG color
-            
-            $temp .= "<tr class='$class'><td><input type='button' text-align='center' onclick=\"location.href='" . PHP_ASELF_ABS . "?mode=reports&no=" . $row['no'] . "';\" value='Clear' /></td>";
-            $temp .= "<td>" . $row['no'] . "</td><td>/" . $row['board'] . "/</td><td>$type</td><td>" . $row['ip'] ." </td>
-            <td><input type='button' text-align='center' onclick=\"location.href='" . PHP_ASELF_ABS . "?mode=more&no=" . $row['no'] . "';\" value=\"Post Info\" /></td>";
-            $temp .= "</tr>";
-            $temp .= "<link rel='stylesheet' type='text/css' href='" . CSS_PATH . "/stylesheets/img.css' />";
-            
-        }
-        
-        return $temp;
-    }
-    
     function error($mes, $no) {
         
         $this->reportFormHead($no);

--- a/_core/admin/report.php
+++ b/_core/admin/report.php
@@ -21,6 +21,7 @@ class Report {
             $this->showForm($_GET['no']);
         } else {
             //Form popup has been submitted, file it.
+            $this-canSubmit($_POST['no']);
             $this->formSubmit($_POST['no'], $_POST['cat']);
         }
         die('</body></html>');
@@ -113,6 +114,7 @@ class Report {
         echo "<head><link rel='stylesheet' type='text/css' href='" . CSS_PATH . "/" . $style . ".css'/><script>function loaded(){window.setTimeout(CloseMe, 3000);}function CloseMe() {window.close();}</script></head><body onLoad='loaded()'>
 	<center><font color=blue size=5>Report submitted! This window will close in 3 seconds...</b></font></center></body>";
     }
+    
     function reportFormHead($no) {
     	global $mysql;
         $style = (NSFW) ? "saguaba" : "sagurichan";

--- a/_core/admin/staff.php
+++ b/_core/admin/staff.php
@@ -4,24 +4,39 @@ class Staff {
 
     function isStaff($user) {
         global $mysql;
-        //See if user exists in mod table. Returns false if user is in table. Why does it do that.
-        if (!$mysql->query(" SELECT `user` FROM " . SQLMODSLOG . " WHERE user='$user'"))
+        //See if user exists in mod table. Returns false if user isn't in table. 
+        if ($mysql->num_rows("SELECT * FROM " . SQLMODSLOG . " WHERE user='$user'") > 0)
             return true;           
         return false;
     }
     
-    function addStaff($user = 0, $pass1 = 0, $pass2 = 0, $perm) {
+    function process($array) {
         global $mysql;
-        //add staff member
-        if (!valid('admin'))
-            error(S_NOPERM);
+        
+        if (!valid('admin')) error(S_NOPERM);
+        
+        $array = [
+            'user'              => $mysql->escape_string($_POST['user']),
+            'pwd1'             => $mysql->escape_string($_POST['pwd1']),
+            'pwd2'             => $mysql->escape_string($_POST['pwd2']),
+            'permission'  => $mysql->escape_string($_POST['action']),
+            'delete'            => $mysql->escape_string($_POST['delete'])
+        ];
 
-         if ($this->isStaff($mysql->escape_string($user)))
+        if (Staff::isStaff($array['user'] && !$array['delete']))
             error("This user already exists!");
+        
+        if ($array['delete'] && Staff::isStaff($array['delete'])) {
+            if ($_COOKIE['saguaro_auser'] == $array['delete'])
+                error("You can't delete yourself!"); //oi ya cheeky shit ill bash yer fookin head in i sware on me mum
+
+            $mysql->query("DELETE FROM " . SQLMODSLOG . " WHERE user='" . $array['delete'] ."'");
+            return true;
+        }
             
-        switch ($perm) {
+        switch ($array['permission']) {
             case 'admin':
-                $allowed = 'all';
+                $allowed = 'janitor_board,janitor,moderator,manager,admin';
                 $denied = 'none';
                 break;
             case 'manager':
@@ -45,36 +60,24 @@ class Staff {
                 break;
         }
         
-        if ($pass1 !== $pass2)
+        if ($array['pwd1'] !== $array['pwd2'])
             error("Passwords did not match!");
             
         require_once(CORE_DIR . "/crypt/legacy.php");
         $crypt = new SaguaroCryptLegacy;
-        $salt = $crypt->generate_hash($pass2);
+        $salt = $crypt->generate_hash($array['pwd2']);
 
-        $mysql->query("INSERT INTO " . SQLMODSLOG . " (`user`, `password`, `public_salt`, `allowed`, `denied`) VALUES ('" . $mysql->escape_string($user) . "', '" . $salt['hash'] . "', '" . $salt['public_salt'] . "', '" . $allowed . "', '" . $denied . "')");
-    }
-    
-    function remStaff($targUser = '', $actUser, $actPass) {
-        global $mysql;    
-        //remove staff member
-        $targUser = $mysql->escape_string($targUser);
-        
-        if (!valid('admin'))
-            error("Permission denied");
-        if ($this->isStaff($targUser))
-            error("User doesn't exist! (GET error?)");
-        if ($_COOKIE['saguaro_auser'] == $targUser)
-            error("You can't delete yourself!"); //oi ya cheeky shit ill bash yer fookin head in i sware on me mum
-        
-        $mysql->query("DELETE FROM " . SQLMODSLOG . " WHERE user='" . $targUser ."'");
+        $mysql->query("INSERT INTO " . SQLMODSLOG . " (`user`, `password`, `public_salt`, `allowed`, `denied`) VALUES ('" . $array['user'] . "', '" . $salt['hash'] . "', '" . $salt['public_salt'] . "', '" . $allowed . "', '" . $denied . "')");
     }
     
     function modifyStaff($targUser, $actUser, $actPass, $perms = array(), $self = 0) {
         //modify existing user
     }
 
-    function getStaff() {
+    function display() {
+        
+        if (!valid('admin'))  error(S_NOPERM);
+        
         global $mysql;
         //Staff list for panel
         
@@ -86,15 +89,15 @@ class Staff {
         $temp .= "<input type=hidden name=pass value=\"$pass\">";
         $temp .= "<div class='delbuttons'>";
         $temp .= "<table class='postlists'><br>";
-        $temp .=  "<tr class='postTable head'><th>User</th><th>Allowed permissions</th><th>Denied permission</th><th>Modify user</th>";
-        $temp .=  "</tr><form action='" . PHP_ASELF_ABS ."?mode=staff' method='get'>";
+        $temp .=  "<tr class='postTable head'><th>User</th><th>Allowed permissions</th><th>Denied permission</th><th>Delete user</th>";
+        $temp .=  "</tr>";
 
         while ($row = $mysql->fetch_assoc($active)) {
                 $j++;               
                 $class = 'row' . ($j % 2 + 1); //BG color
-                $temp .= "<tr class='$class'>";
+                $temp .= "<form action='" . PHP_ASELF_ABS ."?mode=staff' method='post' ><tr class='$class'>";
                 $temp .= "<td>" . $row['user'] . "</td><td>" . $row['allowed'] . "</td><td>" . $row['denied'] . "</td>
-                <td><input type='button' text-align='center' onclick=\"location.href='" . PHP_ASELF_ABS . "?mode=staff&deluse=" . $row['user'] . "';\" value=\"Delete User\" /></td>";
+                <td><input type='submit' value='" . $row['user'] . "' name='delete' /></td>";
                 $temp .= "</tr>";
         }	
         $temp .= "</form><div class='managerBanner' >[<a href='#' onclick=\"toggle_visibility('userForm');\" style='color:white;text-align:center;'>Toggle New User Form</a>]</div>";
@@ -103,10 +106,10 @@ class Staff {
         $temp .= "<td>New password: <input type='password' name='pwd1' required></td><td>Confirm password: <input type='password' name='pwd2' required></td>";
         $temp .= "<td>Access level: <select name='action' required>
             <option value='' /></option>
-            <option value='admin' />Admin</option>
-            <option value='manager' />Manager</option>
-            <option value='mod' />Moderator</option>
-            <option value='janitor' />Global Janitor</option>
+            <option class='cap admin' value='admin' />Admin</option>
+            <option class='cap manager' value='manager' />Manager</option>
+            <option class='cap moderator' value='mod' />Moderator</option>
+            <option class='cap jani' value='janitor' />Global Janitor</option>
             <option value='janitor_board' />Janitor (/" . BOARD_DIR . "/ only)</option>
             </select></td><td><input type='submit' value='Submit'/></td></tr></table></div>";
         return $temp;

--- a/_core/admin/staff.php
+++ b/_core/admin/staff.php
@@ -74,46 +74,6 @@ class Staff {
         //modify existing user
     }
 
-    function display() {
-        
-        if (!valid('admin'))  error(S_NOPERM);
-        
-        global $mysql;
-        //Staff list for panel
-        
-        if (!$active = $mysql->query("SELECT * FROM " . SQLMODSLOG . "")) 
-            echo S_SQLFAIL;
-        $j = 0;
-        $temp = '';
-        $temp .= "<br><br>[<a href='" . PHP_ASELF_ABS . "'>Back to Panel</a><input type='hidden' name='mode' value='admin'>]";
-        $temp .= "<input type=hidden name=pass value=\"$pass\">";
-        $temp .= "<div class='delbuttons'>";
-        $temp .= "<table class='postlists'><br>";
-        $temp .=  "<tr class='postTable head'><th>User</th><th>Allowed permissions</th><th>Denied permission</th><th>Delete user</th>";
-        $temp .=  "</tr>";
-
-        while ($row = $mysql->fetch_assoc($active)) {
-                $j++;               
-                $class = 'row' . ($j % 2 + 1); //BG color
-                $temp .= "<form action='" . PHP_ASELF_ABS ."?mode=staff' method='post' ><tr class='$class'>";
-                $temp .= "<td>" . $row['user'] . "</td><td>" . $row['allowed'] . "</td><td>" . $row['denied'] . "</td>
-                <td><input type='submit' value='" . $row['user'] . "' name='delete' /></td>";
-                $temp .= "</tr>";
-        }	
-        $temp .= "</form><div class='managerBanner' >[<a href='#' onclick=\"toggle_visibility('userForm');\" style='color:white;text-align:center;'>Toggle New User Form</a>]</div>";
-        $temp .= "<div><table id='userForm' style='text-align:center;display:none;'><br><hr style='width:50%;'>";
-        $temp .= "<form action='" . PHP_ASELF_ABS ."?mode=staff' method='post'><tr><td>New username: <input type='text' name='user' required></td>";
-        $temp .= "<td>New password: <input type='password' name='pwd1' required></td><td>Confirm password: <input type='password' name='pwd2' required></td>";
-        $temp .= "<td>Access level: <select name='action' required>
-            <option value='' /></option>
-            <option class='cap admin' value='admin' />Admin</option>
-            <option class='cap manager' value='manager' />Manager</option>
-            <option class='cap moderator' value='mod' />Moderator</option>
-            <option class='cap jani' value='janitor' />Global Janitor</option>
-            <option value='janitor_board' />Janitor (/" . BOARD_DIR . "/ only)</option>
-            </select></td><td><input type='submit' value='Submit'/></td></tr></table></div>";
-        return $temp;
-    }
 }
 
 ?>

--- a/_core/admin/tables.php
+++ b/_core/admin/tables.php
@@ -164,14 +164,15 @@ class Table {
     
     function moreInfo($no) {
         global $mysql;
+		
+		$no = $mysql->escape_string($no);
         
         if (!$result = $mysql->query("SELECT * FROM " . SQLLOG . " WHERE no='" . $no . "'"))
             echo S_SQLFAIL;
         
         $row = $mysql->fetch_row($result);
         list($no, $now, $name, $email, $sub, $com, $host, $pwd, $ext, $w, $h, $tn_w, $tn_h, $tim, $time, $md5, $fsize, $fname, $sticky, $permasage, $locked, $root, $resto, $board, ) = $row;
-        $temp = head(0);
-        $temp .= "<table border='0' cellpadding='0' cellspacing='0'  />";
+        $temp = "<table border='0' cellpadding='0' cellspacing='0'  />";
         $temp .= "<tr>[<a href='" . PHP_ASELF . "' />Return</a>]</tr><br><hr><br>";
         if ($sticky || $locked || $permasage) {
             if ($sticky)
@@ -247,7 +248,7 @@ class Table {
         $temp .= "<center><tr><td><input type='submit' value='Ban'/></td></tr></center></table></form><br><hr>";
         $temp .= "<tr>[<a href='" . PHP_ASELF . "' />Return</a>]</tr><br>";
         
-        echo $temp;
+        return $temp;
     }
     
 }

--- a/_core/admin/tables.php
+++ b/_core/admin/tables.php
@@ -2,7 +2,7 @@
 
 class Table {
     
-    function display($type = 0, $resource = 0) {
+    function deleteTable($type = 0, $resource = 0) {
         global $mysql;
 		
 		require_once(CORE_DIR . "/postform.php");
@@ -251,7 +251,88 @@ class Table {
         
         return $temp;
     }
-    
+  
+     function reportTable() {
+        global $mysql;
+        if (!$active = $mysql->query(" SELECT * FROM reports WHERE board='" . BOARD_DIR . "' AND type>0 ORDER BY `type` DESC "))
+            echo S_SQLFAIL;
+        $j = 0;
+        
+        $temp .= "<br><br><div class='managerBanner'>Active reports for /" . BOARD_DIR . "/ - " . TITLE . "</div>";
+        $temp .= "<table class='postlists'>";
+        $temp .= "<tr class=\"postTable head\"><th>Clear Report</th><th>Post Number</th><th>Board</th><th>Reason</th><th>Reporting IP</th><th>Post info</th>";
+        $temp .= "</tr>";
+        
+        while ($row = $mysql->fetch_array($active)) {
+            $j++;
+
+            switch ($row['type']) {
+                case '1':
+                    $type = 'Spam';
+                    break;
+                case '2':
+                    $type = 'Rule Violation';
+                    break;
+                case '3':
+                    $type = 'Illegal Content';
+                    break;
+                default:
+                    $type = 'Type Error';
+                    break;
+            }
+            $class = ($j % 2) ? "row1" : "row2"; //BG color
+            
+            $temp .= "<tr class='$class'><td><input type='button' text-align='center' onclick=\"location.href='" . PHP_ASELF_ABS . "?mode=reports&no=" . $row['no'] . "';\" value='Clear' /></td>";
+            $temp .= "<td>" . $row['no'] . "</td><td>/" . $row['board'] . "/</td><td>$type</td><td>" . $row['ip'] ." </td>
+            <td><input type='button' text-align='center' onclick=\"location.href='" . PHP_ASELF_ABS . "?mode=more&no=" . $row['no'] . "';\" value=\"Post Info\" /></td>";
+            $temp .= "</tr>";
+            $temp .= "<link rel='stylesheet' type='text/css' href='" . CSS_PATH . "/stylesheets/img.css' />";
+            
+        }
+        
+        return $temp;
+    }
+  
+    function staffTable() {
+        
+        if (!valid('admin'))  error(S_NOPERM);
+        
+        global $mysql;
+        //Staff list for panel
+        
+        if (!$active = $mysql->query("SELECT * FROM " . SQLMODSLOG . "")) 
+            echo S_SQLFAIL;
+        $j = 0;
+        $temp = '';
+        $temp .= "<br><br>[<a href='" . PHP_ASELF_ABS . "'>Back to Panel</a><input type='hidden' name='mode' value='admin'>]";
+        $temp .= "<input type=hidden name=pass value=\"$pass\">";
+        $temp .= "<div class='delbuttons'>";
+        $temp .= "<table class='postlists'><br>";
+        $temp .=  "<tr class='postTable head'><th>User</th><th>Allowed permissions</th><th>Denied permission</th><th>Delete user</th>";
+        $temp .=  "</tr>";
+
+        while ($row = $mysql->fetch_assoc($active)) {
+                $j++;               
+                $class = 'row' . ($j % 2 + 1); //BG color
+                $temp .= "<form action='" . PHP_ASELF_ABS ."?mode=staff' method='post' ><tr class='$class'>";
+                $temp .= "<td>" . $row['user'] . "</td><td>" . $row['allowed'] . "</td><td>" . $row['denied'] . "</td>
+                <td><input type='submit' value='" . $row['user'] . "' name='delete' /></td>";
+                $temp .= "</tr>";
+        }	
+        $temp .= "</form><div class='managerBanner' >[<a href='#' onclick=\"toggle_visibility('userForm');\" style='color:white;text-align:center;'>Toggle New User Form</a>]</div>";
+        $temp .= "<div><table id='userForm' style='text-align:center;display:none;'><br><hr style='width:50%;'>";
+        $temp .= "<form action='" . PHP_ASELF_ABS ."?mode=staff' method='post'><tr><td>New username: <input type='text' name='user' required></td>";
+        $temp .= "<td>New password: <input type='password' name='pwd1' required></td><td>Confirm password: <input type='password' name='pwd2' required></td>";
+        $temp .= "<td>Access level: <select name='action' required>
+            <option value='' /></option>
+            <option class='cap admin' value='admin' />Admin</option>
+            <option class='cap manager' value='manager' />Manager</option>
+            <option class='cap moderator' value='mod' />Moderator</option>
+            <option class='cap jani' value='janitor' />Global Janitor</option>
+            <option value='janitor_board' />Janitor (/" . BOARD_DIR . "/ only)</option>
+            </select></td><td><input type='submit' value='Submit'/></td></tr></table></div>";
+        return $temp;
+    }
 }
 
 ?>

--- a/_core/admin/tables.php
+++ b/_core/admin/tables.php
@@ -166,11 +166,12 @@ class Table {
         global $mysql;
 		
 		$no = $mysql->escape_string($no);
-        
-        if (!$result = $mysql->query("SELECT * FROM " . SQLLOG . " WHERE no='" . $no . "'"))
-            echo S_SQLFAIL;
-        
-        $row = $mysql->fetch_row($result);
+
+        $query = "SELECT * FROM " . SQLLOG . " WHERE no='" . $no . "'";
+        $row = $mysql->fetch_row($query);
+		
+		if (!$row) echo S_SQLFAIL;
+		
         list($no, $now, $name, $email, $sub, $com, $host, $pwd, $ext, $w, $h, $tn_w, $tn_h, $tim, $time, $md5, $fsize, $fname, $sticky, $permasage, $locked, $root, $resto, $board, ) = $row;
         $temp = "<table border='0' cellpadding='0' cellspacing='0'  />";
         $temp .= "<tr>[<a href='" . PHP_ASELF . "' />Return</a>]</tr><br><hr><br>";
@@ -183,11 +184,11 @@ class Table {
                 $special .= "<b><font color=\"2E2EFE\">[Permasaged]</font></b>";
             $temp .= "<tr><td class='postblock'>Special:</td><td class='row2'>This thread is $special</td></tr>"; //lmoa
         }
-        $host = md5($host);
-        $host = substr($host, 12,20);
+        $hashedip = md5($host);
+        $hashedip = substr($hashedip, 12,20);
         $temp .= "<tr><td class='postblock'>Name:</td><td class='row1'>$name</td></tr>
       <tr><td class='postblock'>tempe:</td><td class='row2' />$now</td></tr>
-      <tr><td class='postblock'>IP:</td><td class='row1' /><b>$host</b></td></tr><br>
+      <tr><td class='postblock'>IP:</td><td class='row1' /><b>$hashedip</b></td></tr><br>
       <tr><td class='postblock'>Comment:</td><td class='row2' />$com</td></tr>
       <tr><td class='postblock'>MD5:</td><td class='row1' />$md5</td></tr>
       <tr><td class='postblock'>File</td>";
@@ -212,14 +213,14 @@ class Table {
             </select></td><td><input type='hidden' name='no' value='$no' /><input type='submit' value='Submit'></td></tr></table></form>";
         } else
             $temp .= "</table></form>";
-        $alart = $mysql->num_rows("SELECT COUNT(*) FROM " . SQLBANLOG . " WHERE ip='" . $host . "'");
+        $alart = $mysql->result("SELECT COUNT(*) FROM " . SQLBANLOG . " WHERE host='" . $host . "'", 0, 0);
         if ( $alart > 0)
-            $alert = "<b><font color=\"FF101A\"> $alart ban(s) on record for $host!</font></b>";
+            $alert = "<b><font color=\"FF101A\"> $alart ban(s) on record for $hashedip!</font></b>";
         else
-            $alert = "No bans on record for IP $host";
+            $alert = "No bans on record for IP $hashedip";
         $temp .= "<br><table border='0' cellpadding='0' cellspacing='0' /><form action='admin.php?mode=ban' method='POST' />
         <input type='hidden' name='no' value='$no' />
-        <input type='hidden' name='ip' value='$host' />
+        <input type='hidden' name='ip' value='$hashedip' />
         <center><th class='postblock'><b>Ban panel</b></th></center>
         <tr><td class='postblock'>IP History: </td><td>$alert</td></tr>
         <tr><td class='postblock'>Unban in:</td><td><input type='number' min='0' size='4' name='banlength'  /> days</td></tr>

--- a/_core/admin/tables.php
+++ b/_core/admin/tables.php
@@ -4,6 +4,10 @@ class Table {
     
     function display($type = 0, $resource = 0) {
         global $mysql;
+		
+		require_once(CORE_DIR . "/postform.php");
+		$postform = new PostForm;
+		
             function calculate_age($timestamp, $comparison = '') {
                 $units = array(
                      'second' => 60,
@@ -63,7 +67,9 @@ class Table {
                 $mode = 'ops';
             }            
 
-            // Deletion screen display
+			$temp .= $postform->format(0, 1);
+			
+            // Deletion screen display. Begin HTML generation.
             $temp .= "<div class='managerBanner'>" . S_MANAMODE . "</div>" . $banner;
             $temp .= '<br><form action="' . PHP_ASELF . '" method="get" id="delForm"><input type="hidden" name="mode" value="res">
             <input type="text" name="no" placeholder="Post # or IP" required><input type="submit" value="Search">
@@ -152,9 +158,8 @@ class Table {
             $temp .=  "<link rel='stylesheet' type='text/css' href='" . CSS_PATH . "/stylesheets/img.css' />";
             $all = (int) ($all / 1024);
             //$temp .=  "<div align='center'/>[ " . S_IMGSPACEUSAGE . $all . "</b> KB ]</div>";
-            $temp .= "</body></html>";
 
-            echo $temp;
+            return $temp;
     }
     
     function moreInfo($no) {

--- a/_core/admin/tables.php
+++ b/_core/admin/tables.php
@@ -140,7 +140,7 @@ class Table {
                 $ssno = ($resto) ? $resto : $no;
                 $linknum = /*($resto) ?*/ '<a href="' . PHP_SELF_ABS . "?res=" . $no . '" target="_blank" />' . $no . '</a>';// : '<b><a href="' . PHP_SELF_ABS . "?res=" . $no . '" target="_blank" />' . $no . '</a></b>';
                 $sno = ($sticky) ? "<b><font color=\"FF101A\">$linknum</font></b>" : $linknum;
-                $threadmode = ($resto) ? $resto : $no;    
+                $threadmode = ($last) ? $resto : $no;    
                 $delim = ($size) ? "<td colspan='2'>&nbsp;</td><td colspan='1'>[<b><a href='?mode=adel&no=$no&imgonly=1&refer=$mode'>Delete image?</a>]</b></td><td colspan='3'>&nbsp;</td>" : "<td colspan='6'>&nbsp;</td>";
                 
                 //Actual panel html

--- a/_core/general/error.php
+++ b/_core/general/error.php
@@ -13,9 +13,7 @@ class Error {
             unlink($dest);
 
 
-        /*if ($mes == S_BADHOST) {
-            //die("<html><head><meta http-equiv='refresh' content='0; url=banned.php'></head></html>");
-        } else*/if (!$fancy) {
+        if (!$fancy) {
             require_once(CORE_DIR . "/page/head.php");
             $head = new Head; $head = $head->generate();
             $upfile_name = $_FILES["upfile"]["name"];

--- a/_core/page/foot.php
+++ b/_core/page/foot.php
@@ -16,7 +16,7 @@ class Footer {
         if (file_exists(BOARDLIST))
             $dat .= '<span class="boardlist">' . file_get_contents(BOARDLIST) . '</span>';
 
-        $dat .= '<br><br><div class="footer">' . S_FOOT . '</div><a id="bottom"></a></div></body></html>'; //Last div ends the "afterPosts" class, opened in log.php
+        $dat .= '</div><br><br><div class="footer">' . S_FOOT . '</div><a id="bottom"></a></body></html>'; 
 
         return $dat;
     }

--- a/_core/page/head.php
+++ b/_core/page/head.php
@@ -59,7 +59,7 @@ class Head {
         $dat .= "<link class='togglesheet' rel='alternate stylesheet' type='text/css' media='screen'  href='" . CSS_PATH . CSS3 . "' title='Tomorrow' />";
 
         foreach($this->info['css']['extra'] as $css) {
-            $dat .= "<link rel='stylesheet' type='text/css' href='" . CSS_PATH . "$css'/>";
+            $dat .= "<link rel='stylesheet' type='text/css' href='" . CSS_PATH . $css . ".css'/>";
         }
 
         $dat .= "<script src='" . JS_PATH . "/jquery.min.js' type='text/javascript'></script>

--- a/_core/page/head.php
+++ b/_core/page/head.php
@@ -146,7 +146,7 @@ class Head {
             if (valid('moderator')) {
                 $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=rebuild' title='Rebuild all pages' >Rebuild all</a>]";
                 $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=all' >Deletion panel</a>]";
-                $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=reports' >" . $getReport->reportGetAllBoard() . "</a>]";
+                $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=reports' >" . $getReport->countBoard() . "</a>]";
             }
             if (valid('admin')) {
                 $dat .= "[<a href='" . PHP_ASELF_ABS . "?mode=staff' >Users</a>]";

--- a/_core/page/page.php
+++ b/_core/page/page.php
@@ -15,23 +15,24 @@ class Page {
             'extra' => []
         ]
     ];
-    
-    function generate($middle = '') {
-        return $this->head() . $middle . $this->foot();
+
+    function generate($middle = '', $admin = 0, $noHead = 0) {
+        return $this->head($admin, $noHead) . $middle . $this->foot();
     }
-    
-    function head() {
+
+    function head($admin, $noHead) {
         require_once("head.php");
         $head = new Head;
         $head->info = $this->headVars;
         
-        return $head->generate();
+        return ($admin) ? $head->generateAdmin($noHead) : $head->generate();
     }
-    
+
     function foot() {
         require_once("foot.php");
-        //$footer = new Footer;
-        return Footer::format();//$footer->format();//strict standards prefers <- over -> Footer::format(); for some reason 
+        $footer = new Footer;
+		
+        return $footer->format();//strict standards prefers <- over -> Footer::format(); because it's STRICT
     }
 
 }

--- a/_core/postform.php
+++ b/_core/postform.php
@@ -114,9 +114,11 @@ class PostForm {
         else
             $temp .= "<div class='threadnav' /> [<a href='" . PHP_SELF2_ABS . "#bottom'/>Bottom</a>]  [<a href='/" . BOARD_DIR . "/" . PHP_SELF . "?mode=catalog'>Catalog</a>]</div><hr>";
         
-
+		$temp = "<div id='adminForm' style='display:none; align:center;' />" . $temp . "</div>";
+		
         return $temp;
     }
+
 }
 
 ?>

--- a/_core/postform.php
+++ b/_core/postform.php
@@ -112,7 +112,7 @@ class PostForm {
         else
             $temp .= "<div class='threadnav' /> [<a href='" . PHP_SELF2_ABS . "#bottom'/>Bottom</a>]  [<a href='/" . BOARD_DIR . "/" . PHP_SELF . "?mode=catalog'>Catalog</a>]</div><hr>";
         
-		$temp = "<div id='adminForm' style='display:none; align:center;' />" . $temp . "</div>";
+		if ($admin) $temp = "<div id='adminForm' style='display:none; align:center;' />" . $temp . "</div>";
 		
         return $temp;
     }

--- a/_core/postform.php
+++ b/_core/postform.php
@@ -30,8 +30,6 @@ class PostForm {
         if ($admin) {
             $name = "";
 
-            if (valid('janitor') && JANITOR_CAPCODES) 
-                $name = '<span style="color:#4169E1;font-weight:bold;">Anonymous ## Janitor</span>';
             if (valid('moderator')) 
                 $name = '<span style="color:#770099;font-weight:bold;">Anonymous ## Mod</span>';
             if (valid('manager'))
@@ -51,7 +49,7 @@ class PostForm {
         $temp .= "<table>";
 
         if (!FORCED_ANON) //Name
-        $temp .= "<tr><td class='postblock' align='left'>" . S_NAME . "</td><td align='left'><input type='text' name='name' size='28' placeholder='" . S_ANONAME . "'></td></tr>";
+            $temp .= "<tr><td class='postblock' align='left'>" . S_NAME . "</td><td align='left'><input type='text' name='name' size='28'></td></tr>";
 
         $temp .= "<tr><td class='postblock' align='left'>" . S_EMAIL . "</td><td align='left'><input type='text' name='email' size='28'>";
 

--- a/_core/regist/process/upload.php
+++ b/_core/regist/process/upload.php
@@ -20,7 +20,7 @@ class UploadCheck {
         if ($this->uploadedFile() !== true) error($this->last, $upfile); //File check.
 
         //These checks access the SQL server so we should prioritize these last and then order based on how intensive they are.
-        if ($this->banned() !== true) {if (is_file($upfile)) unlink($upfile); header("Location: banned.php");} //Ban check.
+        if ($this->banned() !== true) { header("Location: banned.php"); die();} //Ban check.
         if ($this->locked() !== true) error($this->last, $upfile); //Lock check.
         if ($this->media() !== true) error($this->last, $upfile); //Media check.
         if ($this->cooldown($upfile) !== true) error($this->last, $upfile); //Flood/cooldown checks.

--- a/_core/regist/regist.php
+++ b/_core/regist/regist.php
@@ -102,7 +102,8 @@ class Regist {
             'sticky'    => $info['post']['special']['sticky'],
             'permasage' => $info['post']['special']['permasage'],
             'locked'    => $info['post']['special']['locked'],
-            'resto'     => ($_POST['resto']) ? (int) $_POST['resto'] : 0
+            'resto'     => ($_POST['resto']) ? (int) $_POST['resto'] : 0,
+            'board'		=> BOARD_DIR
         ];
 
         //Dynamically build the SQL command, numerous advantages.

--- a/_core/regist/thumb/video.php
+++ b/_core/regist/thumb/video.php
@@ -20,6 +20,10 @@ class VideoThumbnail {
         return $temp;
     }
 
+    private function passthrough($temp) {
+
+    }
+
     function thumb_avconv($input, $output, $width, $height) {
         $inputn = preg_replace('/\\.[^.\\s]{3,4}$/', '', $input); //Strip out extension.
         $output = ($output == "auto") ? THUMB_DIR . "/" . $inputn . ".jpg" : $output;

--- a/_core/regist/tripcode.php
+++ b/_core/regist/tripcode.php
@@ -72,7 +72,7 @@ class Tripcode {
         $name2 = strip_tags($name); //Remove anything inserted by tripcode processing
     
         //Travel up the permission tree to get the highest value
-        if(valid('janitor') && JANITOR_CAPCODES)
+        if(valid('janitor') && JANI_CAPCODES)
             $name = "<span class='cap jani'>" . $name2 . " ## Janitor</span>";
         if(valid('moderator')) // Note the combination of the words.
             $name = "<span class='cap moderator'>" . $name2 . " ## Mod</span>";

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -24,9 +24,9 @@ class Post {
         $temp .= "<div class='postInfoM mobile' id='pim$no'><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime'>$now  <a href='#$no' class='quotejs'>No.</a><a href='javascript:insert(\">>$no\")' class='quotejs'>$no</a></span></div>";
         $temp .= "<div class='postInfo desktop'><input type='checkbox' name='$no' value='delete'><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime'>$now</span>";
 
-        $stickyicon = ($sticky) ? ' <img src="' . CSS_PATH . '/imgs/sticky.gif" alt="sticky" title="Stickied thread"> ' : "";
+        $stickyicon = ($sticky) ? ' <img src="' . CSS_PATH . '/imgs/sticky.gif" alt="sticky"> ' : "";
 
-        if ($locked) $stickyicon .= ' <img src="' . CSS_PATH . '/imgs/locked.gif" alt="closed" title="Locked Thread"> ';
+        if ($locked) $stickyicon .= ' <img src="' . CSS_PATH . '/imgs/locked.gif" alt="closed"> ';
 
         if (!$this->inIndex) {
             $temp .= "<a href='#$no' class='permalink' title='Permalink thread'>  No.</a><a href='javascript:insert(\"$no\")' class='quotejs' title='Quote'>$no</a> $stickyicon </div>";

--- a/admin.php
+++ b/admin.php
@@ -39,28 +39,29 @@ function delete_post($resno, $pwd, $imgonly = 0, $automatic = 0, $children = 1, 
 }
 
 function error($mes) { //until error class is sorted out, this is in-house admin error
-    echo "<br><br><hr><br><br><div style='text-align:center;font-size:24px;font-color:blue;'>$mes<br><br><a href='" . PHP_ASELF_ABS . "'>" . S_RELOAD . "</a></div><br><br><hr>";
+    $html = "<br><br><hr><br><br><div style='text-align:center;font-size:24px;font-color:blue;'>$mes<br><br><a href='" . PHP_ASELF_ABS . "'>" . S_RELOAD . "</a></div><br><br><hr>";
+    echo $page->generate($html, true, false);
     die("</body></html>");
 }
 
 /* Main switch */
 switch ($_GET['mode']) {
     case 'res':
-        $html = $table->display($type = 'res', $_GET['no']);
+        $html = $table->displayTable($type = 'res', $_GET['no']);
 		echo $page->generate($html, true);
         break;
     case 'ip' :
-        $html = $table->display($type = 'ip', $_GET['no']);
+        $html = $table->displayTable($type = 'ip', $_GET['no']);
 		echo $page->generate($html, true);
         break;
     case 'ops':
-        $html = $table->display($type = 'ops', 0);
+        $html = $table->displayTable($type = 'ops', 0);
 		echo $page->generate($html, true);
         break;
     case 'staff':
         require_once(CORE_DIR . "/admin/staff.php");
         if ($_POST) Staff::process($_POST);
-        $html = Staff::display();
+        $html = $table->staffTable();
         echo $page->generate($html, true, false);
         break;
     case 'adel':
@@ -80,8 +81,7 @@ switch ($_GET['mode']) {
         break;
     case 'reports':
         if ($_POST['no']) $getReport->clearNum($_POST['no']);
-        $active    = $getReport->countBoard();
-        $html = $getReport->displayTable();
+        $html = $table->reportTable();
         echo $page->generate($html, true, false);
         break;
     case 'news':

--- a/admin.php
+++ b/admin.php
@@ -99,7 +99,8 @@ switch ($_GET['mode']) {
         echo $news->newsPanel();
         break;
     case 'more':
-        echo $table->moreInfo($_GET['no']);
+        $html = $table->moreInfo($_GET['no']);
+		echo $page->generate($html, true, false);
         break;
     case 'modify':
         require_once(CORE_DIR . "/admin/modify.php");

--- a/admin.php
+++ b/admin.php
@@ -47,15 +47,15 @@ function error($mes) { //until error class is sorted out, this is in-house admin
 /* Main switch */
 switch ($_GET['mode']) {
     case 'res':
-        $html = $table->displayTable($type = 'res', $_GET['no']);
+        $html = $table->deleteTable($type = 'res', $_GET['no']);
 		echo $page->generate($html, true);
         break;
     case 'ip' :
-        $html = $table->displayTable($type = 'ip', $_GET['no']);
+        $html = $table->deleteTable($type = 'ip', $_GET['no']);
 		echo $page->generate($html, true);
         break;
     case 'ops':
-        $html = $table->displayTable($type = 'ops', 0);
+        $html = $table->deleteTable($type = 'ops', 0);
 		echo $page->generate($html, true);
         break;
     case 'staff':
@@ -106,7 +106,7 @@ switch ($_GET['mode']) {
         echo "<META HTTP-EQUIV=\"refresh\" content=\"0;URL=" . PHP_SELF2_ABS . "\">";
         break;
     default:
-        $html = $table->display($type = 'all', 0);
+        $html = $table->deleteTable($type = 'all', 0);
 		echo $page->generate($html, true, false);
         break;
 }

--- a/admin.php
+++ b/admin.php
@@ -92,22 +92,17 @@ switch ($_GET['mode']) {
         break;
     case 'adel':
         if (!valid('janitor'))
-                error(S_NOPERM);
+            error(S_NOPERM);
         $no = $mysql->escape_string($_GET['no']);
         $imonly = ($_GET['imgonly'] == '1') ? 0 : 1;
         delete_post($no, 0, $imonly, 0,1,1);
         echo '<meta http-equiv="refresh" content="0; url=' . PHP_ASELF_ABS . '?mode=' . $_GET['refer'] . '" />';
         break;
     case 'ban':
-        if (!valid('moderator'))
-            error(S_NOPERM);
+        if (!valid('moderator')) error(S_NOPERM);
         require_once(CORE_DIR . "/admin/bans.php");
-        $banish = new Banish;
-        if (isset($no)) {
-            $banish->postOptions($no, $ip, $banlength1, $banlength2, $banType, $perma, $pubreason, $staffnote, $custmess, $showbanmess, $afterban);
-            echo "<script>window.close();</script>";
-        }
-        $banish->form($_GET['no']);
+        if ($no) Banish::process($no, $ip, $length, $global, $reason, $pubreason);
+        Banish::form($_GET['no']);
         break;
     case 'more':
         echo $table->moreInfo($_GET['no']);

--- a/admin.php
+++ b/admin.php
@@ -31,11 +31,11 @@ function valid($action = 'moderator', $no = 0) {
     return $valid->verify($action);
 }
 
-function delete_post($resno, $pwd, $imgonly = 0, $automatic = 0, $children = 1, $die = 1) {
+function delete_post($resno, $pwd, $imgonly = 0, $automatic = 0, $children = 1, $die = 1, $delhost = '') {
 	$resno = $mysql->escape_string($resno);
     require_once(CORE_DIR . "/admin/delete.php");
     $remove = new Delete;
-    $remove->targeted($resno, $pwd, $imgonly = 0, $automatic = 0, $children = 1, $die = 1);
+    $remove->targeted($resno, $pwd, $imgonly = 0, $automatic = 0, $children = 1, $die = 1, $delhost = '');
 }
 
 function error($mes) { //until error class is sorted out, this is in-house admin error
@@ -66,13 +66,14 @@ switch ($_GET['mode']) {
         break;
     case 'adel':
         if (!valid('janitor')) error(S_NOPERM);
-        delete_post($_GET['no'], 0, $_GET['imgonly'], 0, 1, 1);
+        delete_post($_GET['no'], 0, $_GET['imgonly'], 0, 1, 1, '');
         break;
     case 'ban':
         if (!valid('moderator')) error(S_NOPERM);
         require_once(CORE_DIR . "/admin/bans.php");
-        if ($_POST['no']) Banish::process($_POST);
-		echo Banish::action($_GET);
+		$bans = new Banish;
+        if ($_POST['no']) $bans->process($_POST);
+		echo $bans->form($_GET);
         break;
     case 'rebuild':
 		if (!valid("admin")) error(S_NOPERM);

--- a/admin.php
+++ b/admin.php
@@ -79,10 +79,10 @@ switch ($_GET['mode']) {
         rebuild(1);
         break;
     case 'reports':
-        head(0);
-        if ($_GET['no']) $getReport->reportClear($_GET['no']);
-        $active    = $getReport->reportGetAllBoard();
-        echo $getReport->reportList();
+        if ($_POST['no']) $getReport->clearNum($_POST['no']);
+        $active    = $getReport->countBoard();
+        $html = $getReport->displayTable();
+        echo $page->generate($html, true, false);
         break;
     case 'news':
         if (!valid('admin')) error(S_NOPERM);

--- a/banned.php
+++ b/banned.php
@@ -1,75 +1,26 @@
 <?php
-include("config.php");
+//Ban status page, 25 lines or less edition! All HTML is in the bans class (bans.php).
+require_once("config.php"); //Kinda uncomfortable about this. 
 
+//Init SQL
 require_once(CORE_DIR . "/mysql/mysql.php");
 $mysql = new SaguaroMySQL;
 $mysql->init();
 
+//Init bans
+require_once(CORE_DIR . "/admin/bans.php");
+$ban  = new Banish;
+
+//Init page class. repod whispers "finally" somehwere.
+require_once(CORE_DIR . "/page/page.php");
+$page = new Page;
+
 $host = $_SERVER['REMOTE_ADDR'];
 
-require_once(CORE_DIR . "/admin/bans.php");
+$status = $ban->isBanned($host); 				//Check if user is banned
+$info = ($status) $ban->banInfo : "none"; 		//If ban exists in the table, get the information array. Otherwise, user isn't banned
+$html = $ban->banScreen($info); 				//Returns all the html for banned.php from the ban class
+echo $page->generate($html); 					//Page class outputs. 
+$ban->append();									//Run checks to see if the ban needs to be updated and we're done here!
 
-$dis  = new Banish;
-$deny = ($dis->isBanned($host)) ? 0 : 1; //no ban : is banned
-
-$status = "are not banned";
-if ($deny) {
-    
-    $row    = $mysql->fetch_assoc("SELECT * FROM " . SQLBANLOG . " WHERE ip='" . $host . "' AND active <> 0 LIMIT 1");
-    $length = ((($row['expires'] - $row['placedon']) / 60) / 60) / 24; //MATH SON
-    
-    switch ($row['type']) {
-        case '1':
-            $status = 'have been warned on: <b>/' . $row['board'] . '/ - ' . TITLE . '</b>';
-            $mysql->query("UPDATE " . SQLBANLOG . " SET active='0' WHERE ip='$host' AND active='1' LIMIT 1"); //Save warnings.
-            break;
-        case '2':
-            $status = 'have been banned from: <b>/' . $row['board'] . '/ - ' . TITLE . '</b>';
-            if (time() > $row['expires'])
-                $mysql->query("DELETE " . SQLBANLOG . " WHERE ip='$host' AND active='1' LIMIT 1");
-            $row['expires'] = date('F d, Y H:i', $row['expires']);
-            break;
-        case '3':
-            $status = 'have been banned from <b>all boards</b>';
-            if (time() > $row['expires'])
-                $mysql->query("DELETE " . SQLBANLOG . " WHERE ip='$host' AND active='1' LIMIT 1");
-            $row['expires'] = date('F d, Y H:i', $row['expires']);
-            break;
-        case '4':
-            $status = 'have been <b>permanently banned from all boards<b>';
-            $length = '<b>forever</b>';
-            $row['expires'] = "never.";
-            break;
-        default:
-            $status      = 'are not banned';
-            $row['type'] = 0;
-            break;
-    }
-    $row['placedon'] = date('F d, Y H:i', $row['placedon']);
-    
-    //for appeals: 0: not able to appeal, 1:appealable. 2:appeal filed. 3: appeal denied.
-    
-}
-
-
-echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head><title>You ' . $status . '</title>
-<link href="' . CSS_PATH . '/stylesheets/bancss.css" rel="stylesheet" type="text/css" /></head><body>
-<div class="container">
-<div class="header"></a><h1>You <b>' . $status . '.</b></h1></div>';
-
-$footer = '<div class="footer"><h2><center>[<a href="' . PHP_SELF2 . '"/>Return</a>]</center></h2></div></div></body></html>';
-
-if ($row['active'] < 1) {
-    //not banned, display the footer, hope the user goes away and doesn't try to talk to me
-    echo '<p>You have no active bans on record.</b>' . $footer;
-} else if ($row['type'] < 2) {
-    echo '<p>You ' . $status . ' for the following reason: </p><br /><p><b>' . $row['reason'] . '</b></p><br /><hr />
-                <p><a href="//' . SITE_ROOT . '/' . RULES . '#' . $row['board'] . '" />Please review the board rules</a> and be aware that further rule violations can result in an extended ban.</p><br />
-                <h3>This warn was issued for the IP address ' . $host . '</h3>' . $footer;
-} else {
-    echo '<p>You <b>' . $status . '</b> for the following reason: </p><br /><p><b>' . $row['reason'] . '</b></p><br /><hr />
-            <p>This ban was placed on <b>' . $row['placedon'] . '</b> and will expire on: <b>' . $row['expires'] . '</b><br/><h3>This ban was issued for the IP address ' . $host . '</h3>' . $footer;
-}
 ?>

--- a/banned.php
+++ b/banned.php
@@ -20,6 +20,5 @@ $host = $_SERVER['REMOTE_ADDR'];
 
 $html = $ban->banScreen(); 				//Returns all the html for banned.php from the ban class
 echo $page->generate($html); 					//Page class outputs. 
-$ban->append($host);									//Run checks to see if the ban needs to be updated and we're done here!
 
 ?>

--- a/banned.php
+++ b/banned.php
@@ -14,11 +14,11 @@ $ban  = new Banish;
 //Init page class. repod whispers "finally" somehwere.
 require_once(CORE_DIR . "/page/page.php");
 $page = new Page;
+$page->headVars['page']['title'] = "You are not banned!";
 
 $host = $_SERVER['REMOTE_ADDR'];
 
-$info = ($ban->isBanned($host)) $ban->banInfo() : "none"; 		//If ban exists in the table, get the information array. Otherwise, user isn't banned
-$html = $ban->banScreen($info); 				//Returns all the html for banned.php from the ban class
+$html = $ban->banScreen(); 				//Returns all the html for banned.php from the ban class
 echo $page->generate($html); 					//Page class outputs. 
 $ban->append($host);									//Run checks to see if the ban needs to be updated and we're done here!
 

--- a/banned.php
+++ b/banned.php
@@ -17,10 +17,9 @@ $page = new Page;
 
 $host = $_SERVER['REMOTE_ADDR'];
 
-$status = $ban->isBanned($host); 				//Check if user is banned
-$info = ($status) $ban->banInfo : "none"; 		//If ban exists in the table, get the information array. Otherwise, user isn't banned
+$info = ($ban->isBanned($host)) $ban->banInfo() : "none"; 		//If ban exists in the table, get the information array. Otherwise, user isn't banned
 $html = $ban->banScreen($info); 				//Returns all the html for banned.php from the ban class
 echo $page->generate($html); 					//Page class outputs. 
-$ban->append();									//Run checks to see if the ban needs to be updated and we're done here!
+$ban->append($host);									//Run checks to see if the ban needs to be updated and we're done here!
 
 ?>

--- a/banned.php
+++ b/banned.php
@@ -16,9 +16,9 @@ require_once(CORE_DIR . "/page/page.php");
 $page = new Page;
 $page->headVars['page']['title'] = "You are not banned!";
 
-$host = $_SERVER['REMOTE_ADDR'];
+$host = $mysql->escape_string($_SERVER['REMOTE_ADDR']);
 
-$html = $ban->banScreen(); 				//Returns all the html for banned.php from the ban class
+$html = $ban->banScreen($host); 				//Returns all the html for banned.php from the ban class
 echo $page->generate($html); 					//Page class outputs. 
 
 ?>

--- a/config.php
+++ b/config.php
@@ -61,6 +61,7 @@ define(BLOTTER_PATH, 'CHANGEME'); //Experimental. Absolute html path to your blo
 
 //Administrative
 define(JANITOR_CAPCODES, false); //Allow janitors to post with a capcode
+define(REPORT_FLOOD, 5); //How many reports a user can file at once.
 
 // Post & Thread
 define(USE_BBCODE, false);  //Use BBcode

--- a/config.php
+++ b/config.php
@@ -169,6 +169,7 @@ define(SQLLOG, PREFIX);            //Table for posting information.
 define(SQLBANLOG, PREFIX.'_ban');  //Table for ban information.
 define(SQLMODSLOG, PREFIX.'_mod'); //Table for mod information (authentication).
 define(SQLDELLOG, PREFIX.'_del');  //Table for deleted information.
+define(SQLBANNOTES, PREFIX.'_ipnotes'); //Table containing IP notes for warned/banned users
 
 //URL pathing.
 define(SITE_SUFFIX, preg_replace('/^.*\.(\w+)$/', '\1', SITE_ROOT));//Domain TLD. By default, this is obtained automatically with regex using SITE_ROOT.

--- a/css/stylesheets/saguaba.css
+++ b/css/stylesheets/saguaba.css
@@ -299,3 +299,29 @@ img.postimg {
     
     z-index: 50;
 }
+
+.container {
+    background: antiquewhite;
+    margin: 20px 200px;
+    border: 1px solid #800000;
+}
+
+.header {
+    background: #EEAA88;
+    border-bottom: 1px solid #800000;
+    font-weight: 700;
+    font-size: 20px;
+    padding: 5px;
+}
+
+.banBody {
+    padding: 10px 20px;
+}
+
+.bannedHost {
+    font-weight: 700;
+}
+
+.reason {
+    font-weight: 700;
+}

--- a/css/stylesheets/sagurichan.css
+++ b/css/stylesheets/sagurichan.css
@@ -276,3 +276,28 @@ img.postimg {
     /*position where enlarged image should offset horizontally */    
     z-index: 50;
 }
+.container {
+    background: #D7DBF2;
+    margin: 20px 200px;
+    border: 1px solid #000000;
+}
+
+.header {
+    background: #9988EE;
+    border-bottom: 1px solid #000000;
+    font-weight: 700;
+    font-size: 20px;
+    padding: 5px;
+}
+
+.banBody {
+    padding: 10px 20px;
+}
+
+.bannedHost {
+    font-weight: 700;
+}
+
+.reason {
+    font-weight: 700;
+}

--- a/css/stylesheets/tomorrow.css
+++ b/css/stylesheets/tomorrow.css
@@ -290,3 +290,29 @@ img.postimg {
     /*position where enlarged image should offset horizontally */
     z-index: 50;
 }
+
+.container {
+    background: #1D1F22;
+    margin: 20px 200px;
+    border: 1px solid #B9BDC3;
+}
+
+.header {
+    background: #5B5E63;
+    border-bottom: 1px solid #B9BDC3;
+    font-weight: 700;
+    font-size: 20px;
+    padding: 5px;
+}
+
+.banBody {
+    padding: 10px 20px;
+}
+
+.bannedHost {
+    font-weight: 700;
+}
+
+.reason {
+    font-weight: 700;
+}

--- a/imgboard.php
+++ b/imgboard.php
@@ -58,7 +58,7 @@ switch ($mode) {
     case 'report':
         require_once(CORE_DIR . "/admin/report.php");
         $report = new Report;
-        $report->reportProcess();
+        $report->process();
         break;
     case 'catalog':
         echo "<META HTTP-EQUIV='refresh' content='0;URL=\"catalog.html\"'>"; //let go of the past

--- a/plugins/jquery/extra/custom_board_list.js
+++ b/plugins/jquery/extra/custom_board_list.js
@@ -1,32 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Allows user to set a custom list of boards to be displayed at the top/bottom board listings.
-*/
+//RePod - Allows user to set a custom list of boards to be displayed at the top/bottom board listings.
 $(document).ready(function() { repod.custom_boardlist.init(); });
 try { repod; } catch(a) { repod = {}; }
 repod.custom_boardlist = {

--- a/plugins/jquery/extra/custom_css.js
+++ b/plugins/jquery/extra/custom_css.js
@@ -1,33 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Allows user to inject custom CSS rules.
-
-*/
+//RePod - Allows user to inject custom CSS rules.
 $(document).ready(function() { repod.custom_css.init(); });
 try { repod; } catch(a) { repod = {}; }
 repod.custom_css = {

--- a/plugins/jquery/extra/hello_world_legacy.js
+++ b/plugins/jquery/extra/hello_world_legacy.js
@@ -1,33 +1,4 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-*/
-
-/*
 This Hello World example file is for scripts that do not use object literals/equivalents. This defines variables in the global namespace
 If you plan on or are currently working on a script using object literals refer to the appropriate Hellow World example file for differences.
 

--- a/plugins/jquery/extra/hello_world_objects.js
+++ b/plugins/jquery/extra/hello_world_objects.js
@@ -1,33 +1,4 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-*/
-
-/*
 This Hello World example file is for scripts that use object literals/equivalents. This defines properties in the relevant namespace.
 If you do not plan on or are currently working on a script not using object literals refer to the appropriate Hellow World example file for differences.
 

--- a/plugins/jquery/extra/images_only.js
+++ b/plugins/jquery/extra/images_only.js
@@ -1,32 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Hide non-images posts when browsing.
-*/
+//RePod - Hide non-images posts when browsing.
 $(document).ready(function() { repod.hide_images.init(); });
 try { repod; } catch(a) { repod = {}; }
 repod.hide_images = {

--- a/plugins/jquery/extra/quick_reply.js
+++ b/plugins/jquery/extra/quick_reply.js
@@ -1,32 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Lets you reply, quickly. Uses the based jQuery Form Plugin.
-*/
+//RePod - Lets you reply, quickly. Uses the based jQuery Form Plugin.
 $(document).ready(function() {
     repod.quick_reply.init();
 });

--- a/plugins/jquery/image_expansion.js
+++ b/plugins/jquery/image_expansion.js
@@ -1,33 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Expands images with their source inside their parent element up to certain dimensions.
-
-*/
+//RePod - Expands images with their source inside their parent element up to certain dimensions.
 $(document).ready(function() { repod.image_expansion.init(); });
 try { repod; } catch(a) { repod = {}; }
 repod.image_expansion = {

--- a/plugins/jquery/image_hover.js
+++ b/plugins/jquery/image_hover.js
@@ -1,33 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Displays the original image when hovering over its thumbnail.
-
-*/
+//RePod - Displays the original image when hovering over its thumbnail.
 $(document).ready(function() { repod.image_hover.init(); });
 try { repod; } catch(a) { repod = {}; }
 repod.image_hover = {

--- a/plugins/jquery/image_toolbar.js
+++ b/plugins/jquery/image_toolbar.js
@@ -1,33 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Appends a toolbar for image posts with links to resources.
-
-*/
+//RePod - Appends a toolbar for image posts with links to resources.
 $(document).ready(function() {
     repod.image_toolbar.init();
 });

--- a/plugins/jquery/infinite_scroll.js
+++ b/plugins/jquery/infinite_scroll.js
@@ -1,33 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-When browsing the index and having reached the bottom, loads the next page. Requires cached page extension to be ".html" or configured below.
-
-*/
+//RePod - When browsing the index and having reached the bottom, loads the next page. Requires cached page extension to be ".html" or configured below.
 $(document).ready(function() { repod.infinite_scroll.init(); });
 try { repod; } catch(a) { repod = {}; }
 repod.infinite_scroll = {

--- a/plugins/jquery/styleswitch.js
+++ b/plugins/jquery/styleswitch.js
@@ -1,32 +1,3 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-*/
-
 $(document).ready(function() { repod.styleswitch.init(); });
 try { repod; } catch(e) { repod = {}; }
 

--- a/plugins/jquery/suite_settings.js
+++ b/plugins/jquery/suite_settings.js
@@ -1,31 +1,3 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-*/
 $(document).ready(function() { repod.suite_settings.init(); });
 repod_suite_settings_pusher = []; //Legacy support. New scripts should push their information to repod.suite_settings.info instead.
 try { repod; } catch(e) { repod = {}; }

--- a/plugins/jquery/thread_stats.js
+++ b/plugins/jquery/thread_stats.js
@@ -1,32 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Shows thread statistics (number of replies, number of image replies out of all replies) above and below threads.
-*/
+//RePod - Shows thread statistics (number of replies, number of image replies out of all replies) above and below threads.
 $(document).ready(function() { repod.thread_stats.init(); });
 try { repod; } catch(a) { repod = {}; }
 repod.thread_stats = {

--- a/plugins/jquery/thread_updater.js
+++ b/plugins/jquery/thread_updater.js
@@ -1,35 +1,6 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Attempts to update threads without reloading the page via jQuery and AJAX.
-Interconnects with other features which are called upon adding new content to the DOM, or not.
-Want a custom function called when new posts are added? Push it to repod.thread_updater.callme.
-
-*/
+//RePod - Attempts to update threads without reloading the page via jQuery and AJAX.
+//Interconnects with other features which are called upon adding new content to the DOM, or not.
+//Want a custom function called when new posts are added? Push it to repod.thread_updater.callme.
 $(document).ready(function() {
     repod.thread_updater.init();
 });

--- a/plugins/jquery/utility_quotes.js
+++ b/plugins/jquery/utility_quotes.js
@@ -1,32 +1,4 @@
-/*
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 RePod
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-ADDITIONALLY, THIS FILE WAS ORIGINALLY CREATED FOR THE SAGUARO IMAGEBOARD SOFTWARE.
-THE ORIGINAL SOFTWARE MAY BE FOUND AT: https://github.com/spootTheLousy/saguaro
-
-Various things involving quotes.
-*/
+//RePod - Various things involving quotes.
 $(document).ready(function() { repod.utility_quotes.init(); });
 try { repod; } catch(e) { repod = {}; }
 repod.utility_quotes = {

--- a/test.php
+++ b/test.php
@@ -263,8 +263,8 @@ if (is_file($lockout)) {
                     //Create tables.
                     $tables = [
                         SQLLOG => "primary key(no), no int not null auto_increment, now text, name text, email text, sub text, com text, host text, pwd text, ext text, w int, h int, tn_w int, tn_h int, tim text, time int, md5 text, fsize int, fname text, sticky int, permasage int, locked int, last int, modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, resto int, board text",
-                        SQLBANLOG => "board VARCHAR(20), global INT(1), name VARCHAR(200), host VARCHAR(50), reason VARCHAR(1000), length INT(25), admin VARCHAR(100), reverse VARCHAR(200), xff VARCHAR(200), placed INT(25) PRIMARY KEY NOT NULL",
-                        SQLMODSLOG => "user VARCHAR(25), password VARCHAR(250), public_salt VARCHAR(256), allowed VARCHAR(250), denied VARCHAR(250), PRIMARY KEY (user, password, public_salt), UNIQUE KEY (user)",
+                        SQLBANLOG => "board VARCHAR(20), global INT(1), name VARCHAR(200), host VARCHAR(50), com VARCHAR(3000), reason VARCHAR(1000), length INT(25), admin VARCHAR(100), placed INT(25) NOT NULL, PRIMARY KEY (board, placed)",
+                        SQLMODSLOG => "user VARCHAR(25), password VARCHAR(250), public_salt VARCHAR(256), allowed VARCHAR(250), denied VARCHAR(250), PRIMARY KEY (user), UNIQUE KEY (user)",
                         SQLDELLOG => "admin VARCHAR(250), postno VARCHAR(20) PRIMARY KEY, action VARCHAR(25), board VARCHAR(250), name VARCHAR(50), sub VARCHAR(50), com VARCHAR(" . S_POSTLENGTH . ")", //Why does S_POSTLENGTH start with S_?
                         "reports" => "no VARCHAR(25), board  VARCHAR(250), type VARCHAR(250), ip VARCHAR(250), reported TIMESTAMP, PRIMARY KEY(no, ip)",
                         "loginattempts" => "userattempt VARCHAR(25) PRIMARY KEY, passattempt VARCHAR(250), board VARCHAR(250), ip VARCHAR(250), attemptno VARCHAR(50)",

--- a/test.php
+++ b/test.php
@@ -266,6 +266,7 @@ if (is_file($lockout)) {
                         SQLBANLOG => "board VARCHAR(20), global INT(1), name VARCHAR(200), host VARCHAR(50), com VARCHAR(3000), reason VARCHAR(1000), length INT(25), admin VARCHAR(100), placed INT(25) NOT NULL, PRIMARY KEY (board, placed)",
                         SQLMODSLOG => "user VARCHAR(25), password VARCHAR(250), public_salt VARCHAR(256), allowed VARCHAR(250), denied VARCHAR(250), PRIMARY KEY (user), UNIQUE KEY (user)",
                         SQLDELLOG => "admin VARCHAR(250), postno VARCHAR(20) PRIMARY KEY, action VARCHAR(25), board VARCHAR(250), name VARCHAR(50), sub VARCHAR(50), com VARCHAR(" . S_POSTLENGTH . ")", //Why does S_POSTLENGTH start with S_?
+                        SQLBANNOTES => "board VARCHAR(25), host VARCHAR(250), type VARCHAR(50), com VARCHAR(3100), reason VARCHAR(2000), admin VARCHAR(250) PRIMARY KEY (host, com)"
                         "reports" => "no VARCHAR(25), board  VARCHAR(250), type VARCHAR(250), ip VARCHAR(250), reported TIMESTAMP, PRIMARY KEY(no, ip)",
                         "loginattempts" => "userattempt VARCHAR(25) PRIMARY KEY, passattempt VARCHAR(250), board VARCHAR(250), ip VARCHAR(250), attemptno VARCHAR(50)",
                         "rebuildqueue" => "board char(4) NOT NULL, no int(11) NOT NULL, ownedby int(11) NOT NULL default '0', ts timestamp NOT NULL default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP, PRIMARY KEY (board,no,ownedby)"

--- a/test.php
+++ b/test.php
@@ -264,7 +264,7 @@ if (is_file($lockout)) {
                     $tables = [
                         SQLLOG => "primary key(no), no int not null auto_increment, now text, name text, email text, sub text, com text, host text, pwd text, ext text, w int, h int, tn_w int, tn_h int, tim text, time int, md5 text, fsize int, fname text, sticky int, permasage int, locked int, last int, modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, resto int, board text",
                         SQLBANLOG => "board VARCHAR(20), global INT(1), name VARCHAR(200), host VARCHAR(50), reason VARCHAR(1000), length DATETIME, admin VARCHAR(100), reverse VARCHAR(200), xff VARCHAR(200), placed TIMESTAMP PRIMARY KEY NOT NULL",
-                        SQLMODSLOG => "user VARCHAR(25), password VARCHAR(250), public_salt VARCHAR(256), allowed VARCHAR(250), denied VARCHAR(250), PRIMARY KEY (user), UNIQUE KEY (user)",
+                        SQLMODSLOG => "user VARCHAR(25), password VARCHAR(250), public_salt VARCHAR(256), allowed VARCHAR(250), denied VARCHAR(250), PRIMARY KEY (user, password, public_salt), UNIQUE KEY (user)",
                         SQLDELLOG => "admin VARCHAR(250), postno VARCHAR(20) PRIMARY KEY, action VARCHAR(25), board VARCHAR(250), name VARCHAR(50), sub VARCHAR(50), com VARCHAR(" . S_POSTLENGTH . ")", //Why does S_POSTLENGTH start with S_?
                         "reports" => "num VARCHAR(250) PRIMARY KEY, no VARCHAR(25), board  VARCHAR(250), type VARCHAR(250), time TIMESTAMP DEFAULT CURRENT_TIMESTAMP, ip VARCHAR(250)",
                         "loginattempts" => "userattempt VARCHAR(25) PRIMARY KEY, passattempt VARCHAR(250), board VARCHAR(250), ip VARCHAR(250), attemptno VARCHAR(50)",

--- a/test.php
+++ b/test.php
@@ -263,7 +263,7 @@ if (is_file($lockout)) {
                     //Create tables.
                     $tables = [
                         SQLLOG => "primary key(no), no int not null auto_increment, now text, name text, email text, sub text, com text, host text, pwd text, ext text, w int, h int, tn_w int, tn_h int, tim text, time int, md5 text, fsize int, fname text, sticky int, permasage int, locked int, last int, modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, resto int, board text",
-                        SQLBANLOG => "board VARCHAR(20), global INT(1), name VARCHAR(200), host VARCHAR(50), reason VARCHAR(1000), length DATETIME, admin VARCHAR(100), reverse VARCHAR(200), xff VARCHAR(200), placed TIMESTAMP PRIMARY KEY NOT NULL",
+                        SQLBANLOG => "board VARCHAR(20), global INT(1), name VARCHAR(200), host VARCHAR(50), reason VARCHAR(1000), length INT(25), admin VARCHAR(100), reverse VARCHAR(200), xff VARCHAR(200), placed INT(25) PRIMARY KEY NOT NULL",
                         SQLMODSLOG => "user VARCHAR(25), password VARCHAR(250), public_salt VARCHAR(256), allowed VARCHAR(250), denied VARCHAR(250), PRIMARY KEY (user, password, public_salt), UNIQUE KEY (user)",
                         SQLDELLOG => "admin VARCHAR(250), postno VARCHAR(20) PRIMARY KEY, action VARCHAR(25), board VARCHAR(250), name VARCHAR(50), sub VARCHAR(50), com VARCHAR(" . S_POSTLENGTH . ")", //Why does S_POSTLENGTH start with S_?
                         "reports" => "no VARCHAR(25), board  VARCHAR(250), type VARCHAR(250), ip VARCHAR(250), reported TIMESTAMP, PRIMARY KEY(no, ip)",

--- a/test.php
+++ b/test.php
@@ -263,7 +263,7 @@ if (is_file($lockout)) {
                     //Create tables.
                     $tables = [
                         SQLLOG => "primary key(no), no int not null auto_increment, now text, name text, email text, sub text, com text, host text, pwd text, ext text, w int, h int, tn_w int, tn_h int, tim text, time int, md5 text, fsize int, fname text, sticky int, permasage int, locked int, last int, modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, resto int, board text",
-                        SQLBANLOG => "num INT(25) PRIMARY KEY AUTO_INCREMENT, ip VARCHAR(25), active INT(1),  placedon VARCHAR(25), expires VARCHAR(25), board VARCHAR(50), type VARCHAR (2), reason VARCHAR(500), staffnotes VARCHAR(500), appeal INT(1) ",
+                        SQLBANLOG => "board VARCHAR(20), global INT(1), name VARCHAR(200), host VARCHAR(50), reason VARCHAR(1000), length DATETIME, admin VARCHAR(100), reverse VARCHAR(200), xff VARCHAR(200), placed TIMESTAMP PRIMARY KEY NOT NULL",
                         SQLMODSLOG => "user VARCHAR(25), password VARCHAR(250), public_salt VARCHAR(256), allowed VARCHAR(250), denied VARCHAR(250), PRIMARY KEY (user), UNIQUE KEY (user)",
                         SQLDELLOG => "admin VARCHAR(250), postno VARCHAR(20) PRIMARY KEY, action VARCHAR(25), board VARCHAR(250), name VARCHAR(50), sub VARCHAR(50), com VARCHAR(" . S_POSTLENGTH . ")", //Why does S_POSTLENGTH start with S_?
                         "reports" => "num VARCHAR(250) PRIMARY KEY, no VARCHAR(25), board  VARCHAR(250), type VARCHAR(250), time TIMESTAMP DEFAULT CURRENT_TIMESTAMP, ip VARCHAR(250)",

--- a/test.php
+++ b/test.php
@@ -266,7 +266,7 @@ if (is_file($lockout)) {
                         SQLBANLOG => "board VARCHAR(20), global INT(1), name VARCHAR(200), host VARCHAR(50), reason VARCHAR(1000), length DATETIME, admin VARCHAR(100), reverse VARCHAR(200), xff VARCHAR(200), placed TIMESTAMP PRIMARY KEY NOT NULL",
                         SQLMODSLOG => "user VARCHAR(25), password VARCHAR(250), public_salt VARCHAR(256), allowed VARCHAR(250), denied VARCHAR(250), PRIMARY KEY (user, password, public_salt), UNIQUE KEY (user)",
                         SQLDELLOG => "admin VARCHAR(250), postno VARCHAR(20) PRIMARY KEY, action VARCHAR(25), board VARCHAR(250), name VARCHAR(50), sub VARCHAR(50), com VARCHAR(" . S_POSTLENGTH . ")", //Why does S_POSTLENGTH start with S_?
-                        "reports" => "num VARCHAR(250) PRIMARY KEY, no VARCHAR(25), board  VARCHAR(250), type VARCHAR(250), time TIMESTAMP DEFAULT CURRENT_TIMESTAMP, ip VARCHAR(250)",
+                        "reports" => "no VARCHAR(25), board  VARCHAR(250), type VARCHAR(250), ip VARCHAR(250), reported TIMESTAMP, PRIMARY KEY(no, ip)",
                         "loginattempts" => "userattempt VARCHAR(25) PRIMARY KEY, passattempt VARCHAR(250), board VARCHAR(250), ip VARCHAR(250), attemptno VARCHAR(50)",
                         "rebuildqueue" => "board char(4) NOT NULL, no int(11) NOT NULL, ownedby int(11) NOT NULL default '0', ts timestamp NOT NULL default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP, PRIMARY KEY (board,no,ownedby)"
                     ];


### PR DESCRIPTION
The aim of this PR is to optimize, rewrite and add functionality to saguaro's ban suite. 
## Checklist:
- [x]  **Under the hood:**
  - [x] Cleaning up **admin.php** removing `extract()` dependency
  - [x] `isBanned()` has redirect to **banned.php** flag option.
  - [x] Optimize/rewrite **banned.php**
    - [x]  Since ban class is initiated in **banned.php** anyway, might be better to have all the checks done in the class, with banned.php just acting as the client end "portal". 
- [ ] **New features:**
  - [x] `autoBan()` function. _Unimplemented right now, might hook into a blacklist later.._ 5832c8f
  - [x] Banned page shows what post ban was filed for 5832c8f
  - [ ] Rangebans
  - [ ] Appeals for bans of certain length. Maybe customizable minimum appeal length. Smells like ~~more config options~~ teen spirit.
- [ ] **Panel - Bans:**
  - [ ] Ban search from panel
  - [ ] Appeal management
- [x] **Redesign:**
  - [x] Banned.php CSS
    - [x] Sagurichan support for WS boards
    - [x] Saguaba support

<hr>

More to come. Ban suite has always been a patchwork of code running on prayer and glue. maybe that will change.
