### PR TITLE
WebM improvements.

### DIFF
--- a/_core/regist/process/video.php
+++ b/_core/regist/process/video.php
@@ -9,22 +9,35 @@
 */
 
 class VideoProcessor {
+    private $cache = [];
+
+    private function initCache() {
+        $this->cache = [
+            'width' => 0,
+            'height' => 0,
+            'duration' => 0.0,
+            'has_video' => false,
+            'has_audio' => false
+        ];
+    }
+
     function process($input) {
+        $this->initCache();
         $upfile_name = $_FILES["upfile"]["name"];
 
         $info = $this->check($input);
 
         if (!$info['has_video'])
-            error("\"$upfile_name\ is not a valid WebM.", $dest);
+            error("\"$upfile_name\" is not a valid WebM.", $input);
         if (ALLOW_AUDIO == false && $info['has_audio'])
-            error("\"$upfile_name\" contains audio!", $dest);
+            error("\"$upfile_name\" contains audio!", $input);
         if ($info['duration'] > MAX_DURATION)
-            error("\"$upfile_name\" is too long! ({$info['duration']} > " . MAX_DURATION . ")", $dest);
+            error("\"$upfile_name\" is too long! ({$info['duration']} > " . MAX_DURATION . ")", $input);
 
         return $info;
     }
 
-    private function check ($input) {
+    private function check($input) {
         if ('which avprobe' || 'where avprobe') { return $this->process_avprobe($input); }
         else if ('which ffprobe' || 'where ffprobe') { return $this->process_ffprobe($input); }
 
@@ -37,7 +50,31 @@ class VideoProcessor {
 
         if (version_compare($version, '0.9', '>=')) {
             //At or above avprobe 0.9, which has extra options (specifically JSON).
-            //Eventually.
+            exec("avprobe -v 0 -show_streams -show_format \"$input\" -of json", $probe);
+            $probe = json_decode(implode($probe,""), true); //Convert the JSON to an associative array.
+            $out = $this->cache;
+
+            if ($probe['format']['nb_streams'] > 2) {
+                $out['has_video'] = false; //Suspicious amount of streams (typically only expect single audio+video).
+                return $out;
+            }
+
+            $out['duration'] = round($probe['format']['duration'],1);
+
+            foreach ($probe['streams'] as $stream) {
+                switch ($stream['codec_type']) {
+                    case 'video':
+                        $out['has_video'] = true;
+                        $out['width'] = $stream['width'];
+                        $out['height'] = $stream['height'];
+                        break;
+                    case 'audio':
+                        $out['has_audio'] = true;
+                        break;
+                }
+            }
+
+            return $out;
         } else {
             //Below avprobe 0.9.
             exec("avprobe -show_format -show_streams $input", $probe);
@@ -62,7 +99,7 @@ class VideoProcessor {
     function process_ffprobe($input) {
         //exec("ffprobe -print_format json -show_format -show_streams $input", $out, $aye);
 
-        var_dump($out);
+        //var_dump($out);
     }
 }
 

--- a/_core/regist/process/video.php
+++ b/_core/regist/process/video.php
@@ -39,7 +39,6 @@ class VideoProcessor {
 
     private function check($input) {
         if ('which avprobe' || 'where avprobe') { return $this->process_avprobe($input); }
-        else if ('which ffprobe' || 'where ffprobe') { return $this->process_ffprobe($input); }
 
         return 0;
     }
@@ -94,12 +93,6 @@ class VideoProcessor {
                 'has_audio' => $has_audio
             ];
         }
-    }
-
-    function process_ffprobe($input) {
-        //exec("ffprobe -print_format json -show_format -show_streams $input", $out, $aye);
-
-        //var_dump($out);
     }
 }
 

--- a/_core/regist/thumb/video.php
+++ b/_core/regist/thumb/video.php
@@ -20,10 +20,6 @@ class VideoThumbnail {
         return $temp;
     }
 
-    private function passthrough($temp) {
-
-    }
-
     function thumb_avconv($input, $output, $width, $height) {
         $inputn = preg_replace('/\\.[^.\\s]{3,4}$/', '', $input); //Strip out extension.
         $output = ($output == "auto") ? THUMB_DIR . "/" . $inputn . ".jpg" : $output;


### PR DESCRIPTION
~~**Don't merge. This may be ready in a few hours based on what I feel like doing to it.**~~
~~[Download testing ZIP.](https://github.com/spootTheLousy/saguaro/archive/webm.zip)~~
- [x] libav/avconv >= `0.9` support (using JSON) (specifically `9.18-6`)
- [x] Possibly drop ffmpeg support entirely due to it being rapidly deprecated.
  - So much so on one of my servers (with libav 0.8) `ffmpeg` is just a proxy to call `avconv`. Same with `*probe`.
- [ ] ~~Make generic thumbnails when we can't extract (via avconv).~~ **Outside of scope.**
  - Potentially later if we want to enable WebM uploads without actually processing them.
- [ ] ~~Integrate check into _test.php_.~~ **Outside of scope.**
  - Currently, _test.php_'s biggest advantage is that it doesn't need anything from __core_, but this will.
  - Eventual _test.php_ rewrite.
