### PR TITLE
Anti-ddos, fix index page numbering

### DIFF
--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -191,7 +191,7 @@ class Log {
                     $dat .= "</form></div>";
                 }
                 for ($i = 1; $i <= PAGE_MAX; $i+=1) {
-                    $dat .= ($i !== $page && ($numThreads > (PAGE_DEF *  $i))) ? "[<a href='{$i}'>{$i}</a>] " : ($i === $page) ? "[<strong>{$i}</strong>] ": "[{$i}] "; //this ones for you hitler
+                    $dat .= ($i !== $page && ($numThreads > (PAGE_DEF *  $i))) ? "[<a href='" . $i . PHP_EXT . "'>{$i}</a>] " : ($i === $page) ? "[<strong>{$i}</strong>] ": "[{$i}] "; //this ones for you hitler
                 }
                 if ($page < PAGE_MAX && ($numThreads > (PAGE_DEF *  $i))) {
                     $dat .= "<div class='nextPage'><form action='" . ($page + 1) . "'>";

--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -212,7 +212,7 @@ class Log {
                     $deferred = $this->update(0);
                 break;
             }
-            $logfilename = (!$page) ? PHP_SELF2 : $page / PAGE_DEF . PHP_EXT;
+            $logfilename = ($page === 1) ? PHP_SELF2 : $page / PAGE_DEF . PHP_EXT;
 
             $this->print_page($logfilename, $dat);
         }


### PR DESCRIPTION
Major changes:
- Index now generated as follows:
  index.html, 2.html, 3.html etc instead of old method:
  index.html, 1.html, 2.html etc.
- Page switcher cleaned up heavily, it's a series of divs now instead of
  a table (gross). Behavior on how it displays pages also changed
  slightly, instead of it adding page links as pages are filled, it shows
  all the pages but will only link them if the number of posts reacches
  that page. Yeah that makes sense probably.
- It was possible to "self-ddos" saguaro just by accessing imgboard.php directly, repeatedly. This has been disabled UNLESS `DEBUG_MODE` is enabled. Only drawback, you can't rebuild the indexes just by accessing imgboard.php.

Some minor cleaning done here:
- cleaned up unnecessarily long if statements
- moved all the `require()` to the top for organization sake
- Buffed rebuild deferral
