### PR TITLE
Regist - Utilize media column in post table.

### DIFF
--- a/_core/delete/delete.php
+++ b/_core/delete/delete.php
@@ -95,7 +95,7 @@ class SaguaroDelete {
 				return $mysql->query("UPDATE " . SQLMEDIA . " SET filesize='-1' WHERE no='$no' and board='" . BOARD_DIR ."'");
 			}
 			
-			$mysql->query("DELETE FROM " . SQLMEDIA . " WHERE parent='{$post['no']}'");
+			$mysql->query("DELETE FROM " . SQLMEDIA . " WHERE parent='{$post['no']}' and board='" . BOARD_DIR ."'");
 			
 			if (is_file($delfile)) unlink($delfile); //Delete image
 			if (is_file($delthumb)) unlink($delthumb); //Delete thumbnail

--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -181,8 +181,8 @@ class Log {
                 } //only one tree line at time of res
             }
 
-            if (USE_ADS3)
-                $dat .= ADS3 . '<hr>';
+            if (ENABLE_ADS)
+                $dat .= ADS_BELOWFORM . '<hr>';
 
             //afterPosts div is closed in general/foot.php
             $dat .= '<div class="afterPosts" /><table align="right"><tr><td class="delsettings" nowrap="nowrap" align="center">

--- a/_core/postform.php
+++ b/_core/postform.php
@@ -97,7 +97,7 @@ class PostForm {
         else
             $temp .= '</table></form></div></div>';
 
-        if (USE_ADS2) $temp .= ADS2 . "<hr>";
+        if (ENABLE_ADS) $temp .= ADS_BELOWFORM . "<hr>";
             
         if (file_exists(GLOBAL_NEWS)) {
             $news = file_get_contents(GLOBAL_NEWS);

--- a/_core/regist/regist.php
+++ b/_core/regist/regist.php
@@ -101,14 +101,16 @@ class Regist {
 
                 $set = $this->dynamicBuild($out);
                 $query = "insert into ".SQLMEDIA." (" . $set['keys'] . ") values (" . $set['vals'] .")";
-                $mysql->query($query);
+                $mysql->query($query); //Disable this to skip writing to the media table.
 
-                array_push($items, $mysql->result('select last_insert_id()'));
+                //array_push($items, $mysql->result('select last_insert_id()')); //Old behavior of just pushing out the media row numbers.
+                unset($out['parent'], $out['resto'], $out['board']); //Delete unnecessary keys.
+                array_push($items, $out); //Push.
             }
-            $items = implode(" ", $items);
+            //$items = implode(" ", $items); //Old behavior of joining the media row numbers.
+            $items = json_encode($items);
 
-
-            //Update the medial column of the parent.
+            //Update the media column of the parent.
             $query = "update ".SQLLOG." set media='$items' where no=$final";
             $mysql->query($query);
         }

--- a/_core/thread/image.php
+++ b/_core/thread/image.php
@@ -25,64 +25,50 @@ class Image {
         if (defined('INTERSTITIAL_LINK'))
             $linksrc = str_replace(INTERSTITIAL_LINK, "", $linksrc);
         $src = IMG_DIR . $localname;
-        if ($fname == 'image')
-            $fname = time();
-        $longname  = $fname;
-        if (!$fname)
+        if ($filename == 'image.jpg')
+            $filename = time();
+        $longname  = $filename;
+        if (!$filename)
             $longname = $localname; //Legacy support for boards that didn't store an $fname in the table pre saguaro 0.99.0
-        $shortname = (strlen($fname) > 40) ? substr($fname, 0, 40) . "(...)" . $ext : $longname;
+        $shortname = (strlen($filename) > 40) ? substr($filename, 0, 40) . "(...)" . $extension : $longname;
         // img tag creation
         $imgsrc    = "";
-        if ($ext !=='.') {
+        if ($extension !=='.') {
             // turn the 32-byte ascii md5 into a 24-byte base64 md5
-            $shortmd5 = base64_encode(pack("H*", $md5));
-            if ($fsize >= 1048576) {
-                $size = round(($fsize / 1048576), 2) . " M";
-            } else if ($fsize >= 1024) {
-                $size = round($fsize / 1024) . " K";
+            $shortmd5 = base64_encode(pack("H*", $hash));
+            if ($filesize >= 1048576) {
+                $size = round(($filesize / 1048576), 2) . " M";
+            } else if ($filesize >= 1024) {
+                $size = round($filesize / 1024) . " K";
             } else {
-                $size = $fsize . " ";
+                $size = $filesize . " ";
             }
 
-            if (!$tn_w && !$tn_h && $ext == ".gif") {
-                $tn_w = $w;
-                $tn_h = $h;
+            if (!$thumb_width && !$thumb_height && $extension == ".gif") {
+                $thumb_width = $width;
+                $thumb_height = $height;
             }
 
             $local = THUMB_DIR . $localthumb;
             $thumb = $thumbdir . $localthumb;
+
             if ($spoiler) {
                 $size   = "Spoiler Image, $size";
-                $imgsrc = "<a href='$displaysrc' target='_blank'><img src='" . CSS_PATH . "/imgs/spoiler.png' border='0' align='left' hspace='20' alt='{$size}B' md5='$shortmd5'></a>";
-            } elseif ($tn_w && $tn_h) { //when there is size...
-                if (@is_file($local)) {
-                    $imgsrc = "<a href='" . $displaysrc . "' target='_blank'><img class='postimg' src='" . $thumb . "' style='margin: 0px 20px;' width='$tn_w' height='$tn_h' alt='" . $size . "B' md5='$shortmd5'></a>";
-                } else {
-                    $imgsrc = "<a href='$displaysrc' target='_blank'><span class='tn_thread' title='{$size}B'>Thumbnail unavailable</span></a>";
-                }
+                $imageFile = "<img src='" . CSS_PATH . "/imgs/spoiler.png' alt='{$size}B' md5='{$shortmd5}'>";
             } else {
-                die('up');
-                if (@is_file($local)) {
-                    $imgsrc = "<a href='$displaysrc' target='_blank'><img class='postimg' src='" . $thumb . "' style='margin: 0px 20px;' alt='{$size}B' md5='$shortmd5'></a>";
-                } else {
-                    $imgsrc = "<a href='$displaysrc' target='_blank'><span class='tn_thread' title='{$size}B'>Thumbnail unavailable</span></a>";
+                if (!$filedeleted && ($thumb_width && $thumb_height)) {
+                    $imageFile = "<img class='postimg' src='" . $thumbdir . $localthumbname . "' {$style} alt='{$size}B' data-md5='{$shortmd5}'>";
                 }
             }
 
-            if (!is_file($local)) {
-                return  "<img src='$cssimg/imgs/filedeleted.gif' alt='File deleted.'>";
+            if ($filedeleted) {
+                return  "<img class='deleted' src='$cssimg/imgs/filedeleted.gif' alt='File deleted.'>";
             } else {
-                $dimensions = ($ext == ".pdf") ? "PDF" : "{$w}x{$h}";
+                $dimensions = ($ext == ".pdf") ? "PDF" : "{$width}x{$height}";
                 $name = ($this->inIndex) ? $shortname : $longname;
-                $temp = "<div class='file'><span class='filesize'>" . S_PICNAME . "<a href='$linksrc' target='_blank'>$name</a> ({$size}B, $dimensions)</span>";
-
-                /* 
-                    if (!$this->inIndex) //, <span title='" . $longname . "'>" . $shortname . "</span>)
-                    $temp .= "</div><div class='fileThumb'>$imgsrc</div>";  //If something is wrong with images, this should be the first thing you check.
-                    else
-                */
-                    $temp .= "</div><div class='fileThumb'>$imgsrc</div>";
-
+                $temp = "<div class='file'  id='f{$no}'><div class='fileText' id='fT{$no}'>" . S_PICNAME . "<a href='$linksrc' target='_blank'>$name</a> ({$size}B, $dimensions)</div>";
+                $temp .= "<a class='fileThumb' href='$displaysrc' target='_blank'>$imageFile</a></div>";
+                clearstatcache();
                 return $temp;
             }
 

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -17,7 +17,13 @@ class Post {
         @extract($this->data);
         $temp = "<div class='thread' id='t$no'/><div class='post op' id='p$no'/><div class='postContainer opContainer' id='pc$no'/>";
 
-        $temp .= $this->media();
+		$image = new Image;
+		$image->inIndex = $this->inIndex;
+
+		$files = json_decode($media, true);
+		foreach ($files as $file) {
+			$temp .= $image->format($file);
+		}
 
         $temp .= "<div class='postInfo desktop'><input type='checkbox' name='$no' value='delete'><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime'>$now</span>";
 
@@ -64,42 +70,19 @@ class Post {
             $temp .= "<a href='" . RES_DIR . $resto . PHP_EXT . "#$no' name='$no' class='permalink' title='Permalink thread' >  No.</a><a href='javascript:insert(\"$no\")' class='quotejs' title='Quote'>$no</a></div>";
         }
 
-        $temp .= $this->media();
+		$image = new Image;
+		$image->inIndex = $this->inIndex;
 
+		$files = json_decode($media, true);
+		foreach ($files as $file) {
+			$temp .= $image->format($file);
+		}
         $com = $this->abbr($com, MAX_LINES_SHOWN, $no, $resto); //yeah sure whatever
         $com = $this->auto_link($com, $resno);
 
         $temp .= "<blockquote class='postMessage' id='m$no'>$com</blockquote>";
 
         $temp .= "</div></div>";
-
-        return $temp;
-    }
-
-    function media() {
-        global $mysql;
-        $temp = "";
-
-        $no = $this->data['no'];
-        $result = $mysql->query("select * from ".SQLMEDIA." where parent=$no");
-        while ($out = $mysql->fetch_assoc($result)) {
-            $stuff = [
-                'localname' => $out['localname'],
-                'localthumb' => $out['localthumbname'],
-                'ext' => $out['extension'],
-                'fname' => $out['filename'],
-                'md5' => $out['hash'],
-                'tn_w' => $out['thumb_width'],
-                'tn_h' => $out['thumb_height'],
-                'w' => $out['width'],
-                'h' => $out['height'],
-                'fsize' => $out['filesize']
-            ];
-
-            $image = new Image;
-            $image->inIndex = $this->inIndex;
-            $temp .= $image->format($stuff);
-        }
 
         return $temp;
     }

--- a/config.php
+++ b/config.php
@@ -131,12 +131,10 @@ define('EXTRA_SHIT', ''); //Any extra javascripts you want to include inside the
 /*
     Advertisements.
 */
-define('USE_ADS1', false);                      //Use advertisements (top)
-define('ADS1', '<center>ads ads ads</center>'); //advertisement code (top)
-define('USE_ADS2', false);                      //Use advertisements (below post form)
-define('ADS2', '<center>ads ads ads</center>'); //advertisement code (below post form)
-define('USE_ADS3', false);                      //Use advertisements (bottom)
-define('ADS3', '<center>ads ads ads</center>'); //advertisement code (bottom)
+define('ENABLE_ADS', false);                      //Use advertisements (top)
+define('ADS_ABOVEFORM', '<center>ads ads ads</center>'); //advertisement code (top)
+define('ADS_BELOWFORM', '<center>ads ads ads</center>'); //advertisement code (below post form)
+define('ADS_AFTERPOSTS', '<center>ads ads ads</center>'); //advertisement code (bottom)
 
 
 /*
@@ -173,6 +171,7 @@ define('SQLMODSLOG', PREFIX.'_mod'); //Table for mod information (authentication
 define('SQLDELLOG', PREFIX.'_del');  //Table for deleted information.
 define('SQLBANNOTES', PREFIX.'_ipnotes'); //Table containing IP notes for warned/banned users
 define('SQLMEDIA', PREFIX.'_media'); //Table for media (or files in general) information.
+define('SQLREPORTS', PREFIX.'_reports'); //Table for report information.
 
 //URL pathing.
 define('SITE_SUFFIX', preg_replace('/^.*\.(\w+)$/', '\1', SITE_ROOT));//Domain TLD. By default, this is obtained automatically with regex using SITE_ROOT.


### PR DESCRIPTION
Uses `json_encode()` (PHP >= 5.2.0) ***recommended, but raises min version***
Honorable mention: `serialize()` (PHP >= 4)

----

Aside from the blind `json_encode()` on the object, filenames could also be sanitized.
A majority of file information is generated ourselves barring filenames/extensions (the latter of which we can normalize).

No matter what, an extra function to "unpack" the contents of the column will need be done.
Unfortunately we will not be able to determine if a post has media without pulling the column (or introducing a new one), otherwise for performance the column should not be pulled ([which is not fun](https://stackoverflow.com/questions/9122/select-all-columns-except-one-in-mysql)). At that point performance/impact is really up to profiling.

More things to consider:
 - If we don't cater our queries, we'll hit theoretical throughput limitations anyway for off-site SQL servers (especially in instances of shared/delegated hosting) and stuck waiting.
   - This is not a new problem and has always existed.
 - The length of each file's instance, with a lot of files, could fill up the media column's text limit.
   - We can compress and arbitrarily not dupe info (like thumb dimensions) but that's not long-term.
 - When the column data is "extracted" we must hope it keeps its data types (it should though).

----

If we go forward with `json_encode()` and set the minimum version requirement to 5.2.0 we should make the additional effort to move to **MySQL*i*** as MySQL is *deprecated* in 5 and removed in 7 (which means saguaro currently refuses to work at all on 7). Beyond that we should also do a brief code review to determine any other problematic areas and swap in PHP5~7 compliant code.

Currently this PR only modifies *Regist* and the rest of saguaro is left alone, with limited new Regist support still in-tact using the media table via reverse lookup. Everything will need to reflect this new change.

----

No matter what I consider this reverting. We'll see in the long run who was right *(me)*.
All the goodness of new Regist with the worst part of old Regist contained in a single column.