### PR TITLE
Improve multi-file display formatting

### DIFF
--- a/_core/regist/inc/thumb/image.php
+++ b/_core/regist/inc/thumb/image.php
@@ -42,7 +42,7 @@ class ImageThumbnail {
         ];
     }
 
-    private function bumpMemory($input) {
+    private function bumpMemory() {
         $this->memory_limit_increased = false;
         $input = $this->stats;
         $pixels = $input['width'] * $input['height'];

--- a/_core/regist/inc/thumb/thumb.php
+++ b/_core/regist/inc/thumb/thumb.php
@@ -7,7 +7,7 @@
 */
 
 //OP thumbnail creation
-function thumb($input, $child) {
+function thumb($input, $child, $filecount) {
     if (!function_exists("ImageCreate") || !function_exists("ImageCreateFromJPEG"))
         return;
 
@@ -16,8 +16,8 @@ function thumb($input, $child) {
     $outpath = THUMB_DIR . pathinfo($input, PATHINFO_FILENAME) . 's.jpg';// . (($ext == 'gif' || $ext == 'png') ? 'png' : 'jpg');
 
     //Determine thumbnail resolution.
-    $width = (!$child) ? MAX_W : MAXR_W;
-    $height = (!$child) ? MAX_H : MAXR_H;
+    $width = (!$child && $filecount < 2) ? MAX_W : MAXR_W;
+    $height = (!$child && $filecount < 2) ? MAX_H : MAXR_H;
 
     if ($ext == "webm") {
         require_once("video.php");
@@ -40,5 +40,3 @@ function thumb($input, $child) {
         'height' => $height
     ];
 }
-
-?>

--- a/_core/regist/regist.php
+++ b/_core/regist/regist.php
@@ -228,6 +228,7 @@ class Regist {
         $files = [];
         $f = $_FILES['upfile'];
         $num_files = count($f['name']);
+        $this->cache['filecount'] = (int) $num_files;
         $max = min($num_files, MAX_FILE_COUNT); //Set the loop cap to the number of files or maximum allowed, whichever is lower.
         if ($num_files > MAX_FILE_COUNT) { //IF we want to impose the file limit and disregard the post itself, this is how we do it.
             //foreach ($f['fname'] as $key => $value) { unlink($value); } //By default, upload files should be in a temporary status and location which PHP should clean up on script completion.
@@ -276,7 +277,7 @@ class Regist {
         require_once("inc/thumb/thumb.php");
         require_once("inc/process/image.php"); //Required for video thumbnail stats.
 
-        $output = thumb($location, ($this->cache['post']['child']));
+        $output = thumb($location, ($this->cache['post']['child']), $this->cache['filecount']);
         if (!$output['location'] && $ext != ".pdf") {
             cleanup(S_UNUSUAL);
         }

--- a/_core/thread/image.php
+++ b/_core/thread/image.php
@@ -10,7 +10,7 @@
 class Image {
     public $inIndex = false; //Really want to start extending as of 30 years ago.
 
-    function format($no, $input) {
+    function format($no, $resto, $input) {
         global $spoiler;
         @extract($input);
 
@@ -66,8 +66,14 @@ class Image {
             } else {
                 $dimensions = ($ext == ".pdf") ? "PDF" : "{$width}x{$height}";
                 $name = ($this->inIndex) ? $shortname : $longname;
-                $temp = "<div class='file'  id='f{$no}'><div class='fileText' id='fT{$no}'>" . S_PICNAME . "<a href='$linksrc' target='_blank'>$name</a> ({$size}B, $dimensions)</div>";
-                $temp .= "<a class='fileThumb' href='$displaysrc' target='_blank'>$imageFile</a></div>";
+                
+                //if ($resto) {
+                    $temp = "<div class='fileImg' id='fim{$no}'>";
+                    $temp .= "<a class='fileThumb' href='$displaysrc' target='_blank'>$imageFile</a><br><div class='fileText' id='fT{$no}'><a href='$linksrc' target='_blank'>$name</a> <br>{$size}B, $dimensions</div></div>";
+                /*} else {
+                    $temp = "<div class='fileImg' id='fim{$no}'><div class='fileText' id='fT{$no}'>" . S_PICNAME . "<a href='$linksrc' target='_blank'>$name</a> ({$size}B, $dimensions)</div>";
+                    $temp .= "<a class='fileThumb' href='$displaysrc' target='_blank'>$imageFile</a></div>";
+                }*/
                 clearstatcache();
                 return $temp;
             }

--- a/_core/thread/post.php
+++ b/_core/thread/post.php
@@ -17,14 +17,6 @@ class Post {
         @extract($this->data);
         $temp = "<div class='thread' id='t$no'/><div class='postContainer opContainer' id='pc$no'/><div class='post op' id='p$no'/>";
 
-		$image = new Image;
-		$image->inIndex = $this->inIndex;
-
-		$files = json_decode($media, true);
-		foreach ($files as $file) {
-			$temp .= $image->format($no, $file);
-		}
-
         $temp .= "<div class='postInfo desktop' id='pi{$no}'><input type='checkbox' name='$no' value='delete'><span class='subject'>$sub</span> <span class='name'>$name</span> <span class='dateTime' data-utc='{$time}'>$now</span>";
 
         $stickyicon = ($sticky) ? ' <img src="' . CSS_PATH . '/imgs/sticky.gif" alt="sticky"> ' : "";
@@ -41,6 +33,20 @@ class Post {
         $com = $this->abbr($com, MAX_LINES_SHOWN, $no, $no); //lol
         $com = $this->auto_link($com, $no);
 
+        
+        $image = new Image;
+        $image->inIndex = $this->inIndex;
+
+        if ($media != null) {
+            $files = json_decode($media, true);
+            $xls = (count($files) > 1) ? "file multi-op" : "file no-multi";
+            $temp .= "<div class='{$xls}'  id='f{$no}'>";
+            foreach ($files as $file) {
+                $temp .= $image->format($no, 0, $file);
+            }
+            $temp .= "</div>";
+        }        
+        
         //$temp .= "<br>";
         $temp .= ($com == "") ? "<blockquote style='display:none;' class='postMessage' id='m$no' >$com</blockquote>" : "<blockquote class='postMessage' id='m$no' >$com</blockquote>";
         $temp .= "</div></div>";
@@ -70,13 +76,19 @@ class Post {
             $temp .= "<a href='" . RES_DIR . $resto . PHP_EXT . "#$no' name='$no' class='permalink' title='Permalink thread' >  No.</a><a href='javascript:insert(\"$no\")' class='quotejs' title='Quote'>$no</a></div>";
         }
 
-		$image = new Image;
-		$image->inIndex = $this->inIndex;
+        $image = new Image;
+        $image->inIndex = $this->inIndex;
 
-		$files = json_decode($media, true);
-		foreach ($files as $file) {
-			$temp .= $image->format($no, $file);
-		}
+        if ($media != null) {
+            $files = json_decode($media, true);
+            $xls = (count($files) > 1) ? "file multi-reply" : "file no-multi-reply";
+            $temp .= "<div class='{$xls}'  id='f{$no}'>";
+            foreach ($files as $file) {
+                $temp .= $image->format($no, $resto, $file);
+            }
+            $temp .= "</div>";
+        }
+        
         $com = $this->abbr($com, MAX_LINES_SHOWN, $no, $resto); //yeah sure whatever
         $com = $this->auto_link($com, $resno);
 

--- a/css/stylesheets/base.css
+++ b/css/stylesheets/base.css
@@ -151,7 +151,7 @@ textarea#comtxt {
     text-decoration: none;
 }
 .deadlink {
-	text-decoration:line-through!important;
+    text-decoration:line-through!important;
 }
 .filesize {
     font-size: 10pt;
@@ -236,17 +236,30 @@ span.cap span.postertrip {
 .postInfoM {
     display: none;
 }
-img.postimg {
-    padding: inherit;
-    padding-bottom: 4pt;
-    float: left;
+.no-multi .fileImg .fileText {
+    text-align: left!important;
+}
+.multi-op, .multi-reply {
+    display: flex;
+    text-align: center;
+    font-size: smaller;
+}
+.multi-reply, .no-multi-reply  .fileImg .fileText {
+    font-size: smaller;
+}
+.no-multi-reply .fileImg {
+    float:left;
+    text-align:center;
+}
+
+.no-multi-reply .fileThumb, .multi-reply .fileThumb {
+    margin-right: 20px;
 }
 .fileThumb {
     float: left;
     margin-top: 3px;
     margin-bottom: 5px;
     margin-left: 20px;
-    margin-right: 20px;
 }
 #blotter {
     width: 468px;

--- a/css/stylesheets/base.css
+++ b/css/stylesheets/base.css
@@ -236,15 +236,18 @@ span.cap span.postertrip {
 .postInfoM {
     display: none;
 }
+.file.no-multi{
+    float:left;
+}
 .no-multi .fileImg .fileText {
-    text-align: left!important;
+    text-align: center!important;
 }
 .multi-op, .multi-reply {
     display: flex;
     text-align: center;
     font-size: smaller;
 }
-.multi-reply, .no-multi-reply  .fileImg .fileText {
+.fileText {
     font-size: smaller;
 }
 .no-multi-reply .fileImg {
@@ -260,6 +263,7 @@ span.cap span.postertrip {
     margin-top: 3px;
     margin-bottom: 5px;
     margin-left: 20px;
+    margin-right: 20px;
 }
 #blotter {
     width: 468px;


### PR DESCRIPTION
Update CSS and post/image formatting classes to make posts with multiple files easier on the eyes.
![image](https://cloud.githubusercontent.com/assets/8524639/22867135/fdd20222-f14f-11e6-8985-5e4c51b0ab0c.png)
