### PR TITLE
Improved API

### DIFF
--- a/_core/api/apoapi.php
+++ b/_core/api/apoapi.php
@@ -1,0 +1,167 @@
+<?php
+
+class SaguaroAPI {
+    public function generatePages() {
+        global $my_log;
+        $log = $my_log->cache;
+        $this->indexes($log);
+        $this->threadList($log);
+        $this->catalog($log);
+        return;
+    }
+    
+    //Create thread specific .json list provided an OP post #
+    public function thread($no) {
+        global $my_log;
+        $log = $my_log->cache;
+        $data = ['posts'=>[]];
+
+        array_push($data['posts'], $this->sanitize($log[$no]));
+
+        if (isset($log[$no]['children'])) {
+            foreach ($log[$no]['children'] as $reply => $value) {
+                array_push($data['posts'], $this->sanitize($log[$reply]));
+            }
+        }
+        $filepath = API_DIR_RES . $no;
+        $this->printFile($filepath, json_encode($data));
+    }
+    
+    //Create json index pages, 0.json, 1.json etc..
+    public function indexes($log) {
+        $pagecount = 0; //This is the page # to start on. 
+        $data = ['threads' => []];
+        $temp = ['posts'=>[]];
+        $threadcount = 0;
+        foreach($log['THREADS'] as $thread) {
+            if ($threadcount >= PAGE_DEF) {
+                $printfile = API_DIR . "/" . $pagecount;
+                $this->printFile($printfile, json_encode($data));
+                $data = ['threads' => []];
+                $threadcount = 0;
+                ++$pagecount;
+            }
+            array_push($temp['posts'], $this->sanitize($log[$thread]));
+            if (isset($log[$thread]['children'])) {
+                ksort($log[$thread]['children']);
+                array_slice($log[$thread]['children'], -4, 4, true);
+                foreach ($log[$thread]['children'] as $reply => $value) {
+                    array_push($temp['posts'], $this->sanitize($log[$reply]));
+                }
+            }
+            array_push($data['threads'], $temp);
+            $temp = ['posts'=>[]];
+            ++$threadcount;
+        }
+        $printfile = API_DIR . "/" . $pagecount;
+        $this->printFile($printfile, json_encode($data));
+    }
+    
+    //Create list of threads, threads.json
+    public function threadList($log) {
+        $pagecount = 0; //This is the page # to start on. 
+        $data = [];
+        $temp = ['page' => $pagecount, 'threads'=>[]];
+        $threadcount = 0;
+        foreach($log['THREADS'] as $thread) {
+            $temp['page'] = $pagecount;
+            if ($threadcount >= PAGE_DEF) {
+                array_push($data, $temp);
+                $temp = ['page' => ++$pagecount, 'threads' => []];
+                $threadcount = 0;
+            }
+            array_push($temp['threads'], [
+                'no'            => (int) $log[$thread]['no'],
+                'last_modified' => (int) $log[$thread]['last_modified']
+            ]);
+            ++$threadcount;
+        }
+        array_push($data, $temp);
+        $printfile = API_DIR . "/threads";
+        $this->printFile($printfile, json_encode($data));
+    }
+
+    //Creates catalog.json
+    //NOTE: the native catalog uses json generated in /catalog/catalog.php , not here!
+    public function catalog($log) {
+        $pagecount = 0; //This is the page # to start on. 
+        $data = [];
+        $temp = ['page' => $pagecount, 'threads'=>[]];
+        $threadcount = 0;
+        foreach($log['THREADS'] as $thread) {
+            $temp['page'] = $pagecount;
+            if ($threadcount >= PAGE_DEF) {
+                array_push($data, $temp);
+                $temp = ['page' => ++$pagecount, 'threads' => []];
+                $threadcount = 0;
+            }
+            array_push($temp['threads'], $this->sanitize($log[$thread], $log));
+            ++$threadcount;
+        }
+        array_push($data, $temp);
+        $printfile = API_DIR . "/catalog";
+        $this->printFile($printfile, json_encode($data));
+    }
+
+    //Remove bad rows from 
+    private function sanitize($temp, $catalog = false) {
+        $bad = ['host', 'media', 'pwd', 'children', 'root', 'ips', 'permasage', 'last', 'modified'];
+        $preserve = ['images','replies','resto', 'imagelimit', 'bumplimit']; //Save these keys even if their value is zero
+
+        if ($temp['media'] != null) {
+            $media = json_decode($temp['media'], true);
+            $temp['filecount'] = count($media);
+            $temp['ext']      = $media[0]['extension'];
+            $temp['tn_w']     = $media[0]['thumb_width'];
+            $temp['tn_h']     = $media[0]['thumb_height'];
+            $temp['w']        = $media[0]['width'];
+            $temp['h']        = $media[0]['height'];
+            $temp['md5']      = $media[0]['hash'];
+            $temp['fsize']    = $media[0]['filesize'];
+            $temp['filename'] = $media[0]['filename'];
+            //$temp['tim']      = $media[0]['CHANGEME'];
+        }
+
+        if (DISPLAY_ID != true) unset($temp['id']);
+
+        if (!$temp['resto']) {
+            if ($temp['images'] > 5) $temp['omitted_images'] = $temp['images'] - 5;
+            if ($temp['replies'] > 5) $temp['omitted_posts'] = $temp['replies'] - 5;
+
+            $temp['unique_ips'] = count($temp['ips']);
+            $temp['imagelimit'] = ($temp['images'] >= MAX_IMGRES) ? 1 : 0;
+            $temp['bumplimit'] = ($temp['replies'] >= MAX_RES) ? 1 : 0;
+            
+            if ($catalog && (count($temp['children']) > 0)) { //Sort catalog's "last_replies" item.
+                $temp['last_replies'] = [];
+                ksort($temp['children']);
+                $temp['children'] = array_slice($temp['children'], -5, 5, true);
+                foreach ($temp['children'] as $reply => $_unused) {
+                    array_push($temp['last_replies'], $this->sanitize($catalog[$reply])); //welcome to my recursive never ending hell
+                }
+           }
+        }
+
+        foreach ($bad as $unset) { //Remove "bad" keys.
+            unset($temp[$unset]);
+        }
+        foreach ($temp as $key => $value) { //Unset null values.
+            if (is_numeric($value)) {
+                $temp[$key] = (int) $value;
+            }
+            if (empty($value) && !in_array($key, $preserve)) {
+                unset($temp[$key]);
+            }
+        }
+        return $temp;
+    }
+    
+    //Writes the json files.
+    private function printFile($filename, $contents) {
+        $filename = $filename . ".json";
+        $tempfile = tempnam(realpath(API_DIR), "tmp"); //note: THIS actually creates the file
+        file_put_contents($tempfile, $contents, FILE_APPEND);
+        rename($tempfile, $filename);
+        chmod($filename, 0664); //it was created 0600
+    }
+}

--- a/_core/delete/delete.php
+++ b/_core/delete/delete.php
@@ -31,9 +31,10 @@ class SaguaroDelete {
 
         foreach ($rebuild as $key => $val) {
             if (ENABLE_API) {
-                require_once(CORE_DIR . "/api/apoi.php");
+                require_once(CORE_DIR . "/api/apoapi.php");
                 $api = new SaguaroAPI;
-                $api->formatThread($key, 0); //Update .json files to reflect deleted posts
+                $api->thread($key); //Update .json files to reflect deleted posts
+                $api->generatePages();
             }
             $my_log->update($key, 1); //Leaving second parameter as 0 rebuilds the index each time!
         }

--- a/_core/log/log.php
+++ b/_core/log/log.php
@@ -185,6 +185,9 @@ class Log {
 
         if (!$resno) { //Rebuild catalog page if index is changed
             $catalog->generate();
+            if (defined('ENABLE_API') && ENABLE_API) {
+                $apiClass->generatePages();
+            }
         }
 
         if (isset($deferred))

--- a/_core/regist/regist.php
+++ b/_core/regist/regist.php
@@ -162,6 +162,12 @@ class Regist {
         $target = ($child) ? $parent : $number;
         $my_log->update($target, $static_rebuild);
 
+        if (defined('ENABLE_API') && ENABLE_API) {
+            require_once(CORE_DIR . "api/apoapi.php");
+            $apiClass = new SaguaroAPI;
+            $apiClass->thread($parent);
+        }
+
         //Auto-noko.
         $url = DATA_SERVER . BOARD_DIR . "/" . RES_DIR;
         $target = $url . $target . PHP_EXT . (($child) ? "#$number" : "");

--- a/config.php
+++ b/config.php
@@ -36,7 +36,13 @@ define('SHOWTITLETXT', true);   //Show TITLE at top. False: hide title'', true: 
 define('SHOWTITLEIMG', false);  //Show image at top
 define('TITLEIMG', '');         //Title image (point to an img rotating script if you want rotating banners)
 define('DATE_FORMAT', 'm/d/y'); //Formatting for the date in each post, see http://php.net/manual/en/function.date.php for different options
-define('ENABLE_API', false); //Don't touch this.
+
+/*
+    Generate .json files as part of saguaro's read only JSON API. 
+    Documentation: https://github.com/saguaroib/saguaro/wiki/API-Documentation
+    Warning: Disabling this will break some aspects of the native javascript extension.
+*/
+define('ENABLE_API', false);
 
 /*
     Specialized board settings - a board with specific purpose
@@ -188,6 +194,13 @@ define('PLUG_PATH_PUBLIC', '//'.SITE_ROOT_BD.'/'.PLUG_PATH); //Public URL path t
 define('JS_PATH', PLUG_PATH_PUBLIC); //jQuery folder. (usually in the plugins folder)
 define('PUBLIC_IMAGE_DIR', '//'.SITE_ROOT_BD.'/'.IMG_DIR); //Web path to a board's image folder
 define('PUBLIC_THUMB_DIR', '//'.SITE_ROOT_BD.'/'.THUMB_DIR);//Web path to a board's thumbnail folder
+
+/*
+    Warning: Changing API pathing may sometimes require modifying header controls on your http server
+    See documentation for more info: https://github.com/saguaroib/saguaro/wiki/API-Documentation#modifying-headers
+*/
+define('API_DIR', '/'); //Path to store catalog.json, index json files and threads.json (not the indivudual thread json files)
+define('API_DIR_RES', API_DIR . 'res/'); //Path to store thread json files
 
 //Posting and Threads
 define('CACHE_TTL', true);          //Thread caching


### PR DESCRIPTION
New API to match the new SQL, this one is much cleaner and more self contained compared to my first implementation.

100% paritry with vichan/yotsuba API formatting, this generates index pages, catalog.json, threads.json as well as each individual thread.

Currently outputs to board directory, with the thread jsons being output in the same folder as the thread HTML. 